### PR TITLE
Changed camera controls to a more traditional RTS style

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ random = "0.12.2"
 fnv = "1.0.3"
 roaring = "0.4.0"
 open = "1.1.1"
+serde = "=0.8.16"
+serde_derive = "=0.8.16"
+serde_json = "=0.8.3"
 
 [dependencies.kay]
 path = "./lib/kay/"

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,3 +3,4 @@ pub mod geometry;
 pub mod simulation;
 pub mod disjoint_sets;
 pub mod grid_accelerator;
+pub mod settings;

--- a/src/core/settings.rs
+++ b/src/core/settings.rs
@@ -1,29 +1,18 @@
-use ::monet::glium::glutin::{Event, MouseScrollDelta, ElementState, MouseButton};
+#![feature(custom_derive)]
+use ::core::ui::KeyOrButton;
 
+#[derive(Serialize, Deserialize, Debug)]
 struct Settings {
-    //Video settings
-    resolution: (i32, i32),
-    vsync: bool,
-
     //Controls
     rotation_speed: f32,
     zoom_speed: f32,
     invert_y: bool,
 
-    mouse1: MouseButton,
-    mouse2: MouseButton,
-    mouse3: MouseButton,
-
-    forward_key: VirtualKeyCode,
-    backward_key: VirtualKeyCode,
-    left_key: VirtualKeyCode,
-    right_key: VirtualKeyCode,
-    pan_modifier_key: VirtualKeyCode,
-
-    //Behavioural - Cars
-    car_length: f32,
-    acceleration: f32,
-    max_deceleration: f32,
-    acceleration_exponent: f32,
-    minimum_spacing: f32,
+    mouse_main: Vec<KeyOrButton>,
+    
+    forward_key: Vec<KeyOrButton>,
+    backward_key: Vec<KeyOrButton>,
+    left_key: Vec<KeyOrButton>,
+    right_key: Vec<KeyOrButton>,
+    pan_modifier_key: Vec<KeyOrButton>,
 }

--- a/src/core/settings.rs
+++ b/src/core/settings.rs
@@ -44,7 +44,6 @@ impl Settings{
         }
     }
 
-    #[allow(let_and_return)]
     pub fn load() -> Settings{
         let path = Path::new("config.json");
         let display = path.display();
@@ -77,7 +76,6 @@ impl Settings{
         if let Err(why) = file.read_to_string(&mut s) {
             panic!("couldn't read {}: {}", display, why.description())
         }
-        let ret: Settings = serde_json::from_str(&s).unwrap();
-        ret
+        serde_json::from_str::<Settings>(&s).unwrap()
     }
 }

--- a/src/core/settings.rs
+++ b/src/core/settings.rs
@@ -1,8 +1,15 @@
-#![feature(custom_derive)]
+#![feature(rustc_macro)]
 use ::core::ui::KeyOrButton;
+use ::monet::glium::glutin::{MouseButton, VirtualKeyCode};
+use serde_json;
 
-#[derive(Serialize, Deserialize, Debug)]
-struct Settings {
+use std::error::Error;
+use std::fs::File;
+use std::io::prelude::*;
+use std::path::Path;
+
+#[derive(Serialize, Deserialize)]
+pub struct Settings {
     //Controls
     rotation_speed: f32,
     zoom_speed: f32,
@@ -15,4 +22,61 @@ struct Settings {
     left_key: Vec<KeyOrButton>,
     right_key: Vec<KeyOrButton>,
     pan_modifier_key: Vec<KeyOrButton>,
+    rotate_modifier_key: Vec<KeyOrButton>,
+}
+
+impl Settings{
+    pub fn new() -> Settings{
+        Settings{
+            rotation_speed: 1.0f32,
+            zoom_speed: 1.0f32,
+            invert_y: false,
+
+            mouse_main: vec![KeyOrButton::Button(MouseButton::Left)],
+            forward_key: vec![KeyOrButton::Key(VirtualKeyCode::W), KeyOrButton::Key(VirtualKeyCode::Up)],
+            backward_key: vec![KeyOrButton::Key(VirtualKeyCode::S), KeyOrButton::Key(VirtualKeyCode::Down)],
+            left_key: vec![KeyOrButton::Key(VirtualKeyCode::A), KeyOrButton::Key(VirtualKeyCode::Left)],
+            right_key: vec![KeyOrButton::Key(VirtualKeyCode::D), KeyOrButton::Key(VirtualKeyCode::Right)],
+
+            pan_modifier_key:    vec![KeyOrButton::Key(VirtualKeyCode::LShift), KeyOrButton::Key(VirtualKeyCode::RShift)],
+            rotate_modifier_key: vec![KeyOrButton::Button(MouseButton::Middle)],
+        }
+    }
+
+    pub fn load() -> Settings{
+        let path = Path::new("config.json");
+        let display = path.display();
+        let settings = Settings::new();
+
+        let mut file = match File::open(&path) {
+            Err(why) => {
+                println!("Config file does not exist, creating new one");
+                match File::create(&path) {
+                    Err(why) => panic!("couldn't create {}: {}", display, why.description()),
+                    Ok(mut file) => {
+                        let serialized = serde_json::to_string(&settings).expect("Could not serialise Settings");
+                        match file.write_all(serialized.as_bytes()) {
+                            Err(why) => {
+                                panic!("couldn't write config to {}: {}", display, why.description())
+                            },
+                            Ok(_) => println!("successfully wrote new config to {}", display),
+                        }
+                        file = match File::open(&path) {
+                            Err(why) => panic!("couldn't open {}, which was just written to: {}", display, why.description()),
+                            Ok(file) => file,
+                        };
+                        file
+                    },
+                }
+            }
+            Ok(file) => file,
+        };
+        let mut s = String::new();
+        match file.read_to_string(&mut s) {
+            Err(why) => panic!("couldn't read {}: {}", display, why.description()),
+            Ok(_) => (),
+        }
+        let deserialized: Settings = serde_json::from_str(&s).unwrap();
+        deserialized
+    }
 }

--- a/src/core/settings.rs
+++ b/src/core/settings.rs
@@ -8,21 +8,22 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::path::Path;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, PartialEq)]
 pub struct Settings {
     //Controls
-    rotation_speed: f32,
-    zoom_speed: f32,
-    invert_y: bool,
+    pub rotation_speed: f32,
+    pub move_speed: f32,
+    pub zoom_speed: f32,
+    pub invert_y: bool,
 
-    mouse_main: Vec<KeyOrButton>,
+    pub mouse_main: Vec<KeyOrButton>,
     
-    forward_key: Vec<KeyOrButton>,
-    backward_key: Vec<KeyOrButton>,
-    left_key: Vec<KeyOrButton>,
-    right_key: Vec<KeyOrButton>,
-    pan_modifier_key: Vec<KeyOrButton>,
-    rotate_modifier_key: Vec<KeyOrButton>,
+    pub forward_key: Vec<KeyOrButton>,
+    pub backward_key: Vec<KeyOrButton>,
+    pub left_key: Vec<KeyOrButton>,
+    pub right_key: Vec<KeyOrButton>,
+    pub pan_modifier_key: Vec<KeyOrButton>,
+    pub rotate_modifier_key: Vec<KeyOrButton>,
 }
 
 impl Settings{
@@ -30,6 +31,7 @@ impl Settings{
         Settings{
             rotation_speed: 1.0f32,
             zoom_speed: 1.0f32,
+            move_speed: 1.0f32,
             invert_y: false,
 
             mouse_main: vec![KeyOrButton::Button(MouseButton::Left)],

--- a/src/core/settings.rs
+++ b/src/core/settings.rs
@@ -1,0 +1,29 @@
+use ::monet::glium::glutin::{Event, MouseScrollDelta, ElementState, MouseButton};
+
+struct Settings {
+    //Video settings
+    resolution: (i32, i32),
+    vsync: bool,
+
+    //Controls
+    rotation_speed: f32,
+    zoom_speed: f32,
+    invert_y: bool,
+
+    mouse1: MouseButton,
+    mouse2: MouseButton,
+    mouse3: MouseButton,
+
+    forward_key: VirtualKeyCode,
+    backward_key: VirtualKeyCode,
+    left_key: VirtualKeyCode,
+    right_key: VirtualKeyCode,
+    pan_modifier_key: VirtualKeyCode,
+
+    //Behavioural - Cars
+    car_length: f32,
+    acceleration: f32,
+    max_deceleration: f32,
+    acceleration_exponent: f32,
+    minimum_spacing: f32,
+}

--- a/src/core/settings.rs
+++ b/src/core/settings.rs
@@ -1,4 +1,3 @@
-#![feature(rustc_macro)]
 use ::core::ui::KeyOrButton;
 use ::monet::glium::glutin::{MouseButton, VirtualKeyCode};
 use serde_json;
@@ -51,7 +50,7 @@ impl Settings{
         let settings = Settings::new();
 
         let mut file = match File::open(&path) {
-            Err(why) => {
+            Err(_) => {
                 println!("Config file does not exist, creating new one");
                 match File::create(&path) {
                     Err(why) => panic!("couldn't create {}: {}", display, why.description()),
@@ -74,11 +73,10 @@ impl Settings{
             Ok(file) => file,
         };
         let mut s = String::new();
-        match file.read_to_string(&mut s) {
-            Err(why) => panic!("couldn't read {}: {}", display, why.description()),
-            Ok(_) => (),
+        if let Err(why) = file.read_to_string(&mut s) {
+            panic!("couldn't read {}: {}", display, why.description())
         }
-        let deserialized: Settings = serde_json::from_str(&s).unwrap();
-        deserialized
+        let ret: Settings = serde_json::from_str(&s).unwrap();
+        ret
     }
 }

--- a/src/core/settings.rs
+++ b/src/core/settings.rs
@@ -44,6 +44,7 @@ impl Settings{
         }
     }
 
+    #[allow(let_and_return)]
     pub fn load() -> Settings{
         let path = Path::new("config.json");
         let display = path.display();

--- a/src/core/ui.rs
+++ b/src/core/ui.rs
@@ -7,6 +7,12 @@ pub use ::monet::glium::glutin::{VirtualKeyCode};
 use core::geometry::AnyShape;
 use ::std::collections::HashMap;
 
+#[derive(Copy, Clone, Debug)]
+pub enum KeyOrButton{
+    Key(VirtualKeyCode),
+    Button(MouseButton),
+}
+
 #[derive(Copy, Clone)]
 enum Mouse {
     Moved(P2),

--- a/src/core/ui.rs
+++ b/src/core/ui.rs
@@ -7,6 +7,43 @@ pub use ::monet::glium::glutin::{VirtualKeyCode};
 use core::geometry::AnyShape;
 use ::std::collections::HashMap;
 
+#[derive(Copy, Clone)]
+enum Mouse {
+    Moved(P2),
+    Scrolled(P2),
+    Down(MouseButton),
+    Up(MouseButton),
+}
+
+pub struct InputState {
+    forward: bool,
+    backward: bool,
+
+    left: bool,
+    right: bool,
+
+    rotate_mod: bool,
+    pan_mod: bool,
+
+    mouse: Vec<Mouse>,
+}
+
+impl InputState {
+    fn new() -> InputState {
+        InputState {
+            forward: false,
+            backward: false,
+            left: false,
+            right: false,
+
+            rotate_mod: false,
+            pan_mod: false,
+
+            mouse: vec![],
+        }
+    }
+}
+
 pub struct UserInterface {
     interactables_2d: HashMap<ID, (AnyShape, usize)>,
     interactables_3d: HashMap<ID, (AnyShape, usize)>,
@@ -17,12 +54,12 @@ pub struct UserInterface {
     hovered_interactable: Option<ID>,
     active_interactable: Option<ID>,
     focused_interactable: Option<ID>,
-    space_pressed: bool,
-    shift_pressed: bool
+    input_state: InputState,
 }
-impl Individual for UserInterface{}
 
-impl UserInterface{
+impl Individual for UserInterface {}
+
+impl UserInterface {
     fn new() -> UserInterface {
         UserInterface {
             interactables_2d: HashMap::new(),
@@ -34,192 +71,267 @@ impl UserInterface{
             hovered_interactable: None,
             active_interactable: None,
             focused_interactable: None,
-            space_pressed: false,
-            shift_pressed: false
+            input_state: InputState::new(),
         }
     }
 }
 
 #[derive(Compact, Clone)]
-pub enum Add{Interactable2d(ID, AnyShape, usize), Interactable3d(ID, AnyShape, usize)}
+pub enum Add {
+    Interactable2d(ID, AnyShape, usize),
+    Interactable3d(ID, AnyShape, usize)
+}
 
 impl Recipient<Add> for UserInterface {
-    fn receive(&mut self, msg: &Add) -> Fate {match *msg{
-        Add::Interactable2d(_id, ref _shape, _z_index) => unimplemented!(),
-        Add::Interactable3d(id, ref shape, z_index) => {
-            self.interactables_3d.insert(id, (shape.clone(), z_index));
-            Fate::Live
+    fn receive(&mut self, msg: &Add) -> Fate {
+        match *msg {
+            Add::Interactable2d(_id, ref _shape, _z_index) => unimplemented!(),
+            Add::Interactable3d(id, ref shape, z_index) => {
+                self.interactables_3d.insert(id, (shape.clone(), z_index));
+                Fate::Live
+            }
         }
-    }}
+    }
 }
 
 #[derive(Copy, Clone)]
-pub enum Remove{Interactable2d(ID), Interactable3d(ID)}
+pub enum Remove {
+    Interactable2d(ID),
+    Interactable3d(ID)
+}
 
 impl Recipient<Remove> for UserInterface {
-    fn receive(&mut self, msg: &Remove) -> Fate {match *msg{
-        Remove::Interactable2d(_id) => unimplemented!(),
-        Remove::Interactable3d(id) => {
-            self.interactables_3d.remove(&id);
-            Fate::Live
+    fn receive(&mut self, msg: &Remove) -> Fate {
+        match *msg {
+            Remove::Interactable2d(_id) => unimplemented!(),
+            Remove::Interactable3d(id) => {
+                self.interactables_3d.remove(&id);
+                Fate::Live
+            }
         }
-    }}
+    }
 }
 
 #[derive(Copy, Clone)]
 pub struct Focus(pub ID);
 
 impl Recipient<Focus> for UserInterface {
-    fn receive(&mut self, msg: &Focus) -> Fate {match *msg{
-        Focus(id) => {
-            self.focused_interactable = Some(id);
-            Fate::Live
+    fn receive(&mut self, msg: &Focus) -> Fate {
+        match *msg {
+            Focus(id) => {
+                self.focused_interactable = Some(id);
+                Fate::Live
+            }
         }
-    }}
+    }
 }
-
-#[derive(Copy, Clone)]
-enum Mouse{Moved(P2), Scrolled(P2), Down, Up}
 
 use ::monet::Project2dTo3d;
 
 #[derive(Copy, Clone)]
-pub enum Event3d{
-    DragStarted{at: P3},
-    DragOngoing{from: P3, to: P3},
-    DragFinished{from: P3, to: P3},
+pub enum Event3d {
+    DragStarted {
+        at: P3
+    },
+    DragOngoing {
+        from: P3,
+        to: P3
+    },
+    DragFinished {
+        from: P3,
+        to: P3
+    },
     DragAborted,
-    HoverStarted{at: P3},
-    HoverOngoing{at: P3},
+    HoverStarted {
+        at: P3
+    },
+    HoverOngoing {
+        at: P3
+    },
     HoverStopped,
     KeyDown(VirtualKeyCode),
     KeyUp(VirtualKeyCode)
 }
 
 impl Recipient<Mouse> for UserInterface {
-    fn receive(&mut self, msg: &Mouse) -> Fate {match *msg{
-        Mouse::Moved(position) => {
-            let delta = self.cursor_2d - position;
-            if self.space_pressed {
-                if self.shift_pressed {
-                    Renderer::id() << MoveEye{scene_id: 0, movement: ::monet::Movement::Rotate(-delta.x/300.0)};
-                    Renderer::id() << MoveEye{scene_id: 0, movement: ::monet::Movement::Zoom(-delta.y)};
-                    self.cursor_2d = position;
-                } else {
-                    Renderer::id() << MoveEye{scene_id: 0, movement: ::monet::Movement::Shift(V3::new(-delta.y / 3.0, delta.x / 3.0, 0.0))};                
-                    self.cursor_2d = position;
-                }
-            } else {
-                self.cursor_2d = position;
-                Renderer::id() << Project2dTo3d{
-                    scene_id: 0,
-                    position_2d: position,
-                    requester: Self::id()
-                };
-            }
-            Fate::Live
-        },
-        Mouse::Scrolled(delta) => {
-            Renderer::id() << MoveEye{scene_id: 0, movement: ::monet::Movement::Shift(V3::new(delta.y / 5.0, -delta.x / 5.0, 0.0))};
-            Fate::Live
-        },
-        Mouse::Down => {
-            self.drag_start_2d = Some(self.cursor_2d);
-            self.drag_start_3d = Some(self.cursor_3d);
-            let cursor_3d = self.cursor_3d;
-            self.receive(&Projected3d{position_3d: cursor_3d});
-            self.active_interactable = self.hovered_interactable;
-            if let Some(active_interactable) = self.active_interactable{
-                active_interactable << Event3d::DragStarted{at: self.cursor_3d};
-            }
-            Fate::Live
-        },
-        Mouse::Up => {
-            if let Some(active_interactable) = self.active_interactable {
-                active_interactable << Event3d::DragFinished{
-                    from: self.drag_start_3d.expect("active interactable but no drag start"),
-                    to: self.cursor_3d
-                };
-            }
-            self.drag_start_2d = None;
-            self.drag_start_3d = None;
-            self.active_interactable = None;
-            Fate::Live
+    fn receive(&mut self, msg: &Mouse) -> Fate {
+        self.input_state.mouse.push(*msg);
+        match *msg {
+            Mouse::Down(MouseButton::Middle) => self.input_state.rotate_mod = true,
+            Mouse::Up(MouseButton::Middle) => self.input_state.rotate_mod = false,
+            _ => ()
         }
-    }}
+        Fate::Live
+    }
 }
 
 #[derive(Copy, Clone)]
-enum Key{Up(VirtualKeyCode), Down(VirtualKeyCode)}
+enum Key {
+    Up(VirtualKeyCode),
+    Down(VirtualKeyCode)
+}
 
 impl Recipient<Key> for UserInterface {
-    fn receive(&mut self, msg: &Key) -> Fate {match *msg {
-        Key::Down(key_code) => {
-            match key_code {
-                VirtualKeyCode::Space => {
-                    self.space_pressed = true;
-                },
-                VirtualKeyCode::LShift | VirtualKeyCode::RShift => {
-                    self.shift_pressed = true;
-                },
-                _ => {}
+    fn receive(&mut self, msg: &Key) -> Fate {
+        match *msg {
+            Key::Down(key_code) => {
+                match key_code {
+                    VirtualKeyCode::W => {
+                        self.input_state.forward = true;
+                    },
+                    VirtualKeyCode::S => {
+                        self.input_state.backward = true;
+                    },
+                    VirtualKeyCode::A => {
+                        self.input_state.left = true;
+                    },
+                    VirtualKeyCode::D => {
+                        self.input_state.right = true;
+                    },
+
+                    VirtualKeyCode::LShift | VirtualKeyCode::RShift => {
+                        self.input_state.pan_mod = true;
+                    },
+                    _ => {}
+                }
+                self.focused_interactable.map(|interactable|
+                    interactable << Event3d::KeyDown(key_code)
+                );
+                Fate::Live
+            },
+            Key::Up(key_code) => {
+                match key_code {
+                    VirtualKeyCode::W => {
+                        self.input_state.forward = false;
+                    },
+                    VirtualKeyCode::S => {
+                        self.input_state.backward = false;
+                    },
+                    VirtualKeyCode::A => {
+                        self.input_state.left = false;
+                    },
+                    VirtualKeyCode::D => {
+                        self.input_state.right = false;
+                    },
+
+                    VirtualKeyCode::LShift | VirtualKeyCode::RShift => {
+                        self.input_state.pan_mod = false;
+                    },
+                    _ => {}
+                }
+                self.focused_interactable.map(|interactable|
+                    interactable << Event3d::KeyUp(key_code)
+                );
+                Fate::Live
             }
-            self.focused_interactable.map(|interactable|
-                interactable << Event3d::KeyDown(key_code)
-            );
-            Fate::Live
-        },
-        Key::Up(key_code) => {
-            match key_code {
-                VirtualKeyCode::Space => {
-                    self.space_pressed = false;
-                },
-                VirtualKeyCode::LShift | VirtualKeyCode::RShift => {
-                    self.shift_pressed = false;
-                },
-                _ => {}
-            }
-            self.focused_interactable.map(|interactable|
-                interactable << Event3d::KeyUp(key_code)
-            );
-            Fate::Live
         }
-    }}
+    }
 }
 
 use ::monet::Projected3d;
 
 impl Recipient<Projected3d> for UserInterface {
-    fn receive(&mut self, msg: &Projected3d) -> Fate {match *msg{
-        Projected3d{position_3d} => {
-            self.cursor_3d = position_3d;
-            if let Some(active_interactable) = self.active_interactable {
-                active_interactable << Event3d::DragOngoing{
-                    from: self.drag_start_3d.expect("active interactable but no drag start"),
-                    to: position_3d
-                };
-            } else {
-                let new_hovered_interactable = self.interactables_3d.iter().filter(|&(_id, &(ref shape, _z_index))|
-                    shape.contains(position_3d.into_2d())
-                ).max_by_key(|&(_id, &(ref _shape, z_index))|
-                    z_index
-                ).map(|(id, _shape)| *id);
+    fn receive(&mut self, msg: &Projected3d) -> Fate {
+        match *msg {
+            Projected3d { position_3d } => {
+                self.cursor_3d = position_3d;
+                if let Some(active_interactable) = self.active_interactable {
+                    active_interactable << Event3d::DragOngoing {
+                        from: self.drag_start_3d.expect("active interactable but no drag start"),
+                        to: position_3d
+                    };
+                } else {
+                    let new_hovered_interactable = self.interactables_3d.iter().filter(|&(_id, &(ref shape, _z_index))|
+                        shape.contains(position_3d.into_2d())
+                    ).max_by_key(|&(_id, &(ref _shape, z_index))|
+                        z_index
+                    ).map(|(id, _shape)| *id);
 
-                if self.hovered_interactable != new_hovered_interactable {
-                    if let Some(previous) = self.hovered_interactable {
-                        previous << Event3d::HoverStopped;
+                    if self.hovered_interactable != new_hovered_interactable {
+                        if let Some(previous) = self.hovered_interactable {
+                            previous << Event3d::HoverStopped;
+                        }
+                        if let Some(next) = new_hovered_interactable {
+                            next << Event3d::HoverStarted { at: self.cursor_3d };
+                        }
+                    } else if let Some(hovered_interactable) = self.hovered_interactable {
+                        hovered_interactable << Event3d::HoverOngoing { at: self.cursor_3d };
                     }
-                    if let Some(next) = new_hovered_interactable {
-                        next << Event3d::HoverStarted{at: self.cursor_3d};
-                    }
-                } else if let Some(hovered_interactable) = self.hovered_interactable {
-                    hovered_interactable << Event3d::HoverOngoing{at: self.cursor_3d};
+                    self.hovered_interactable = new_hovered_interactable;
                 }
-                self.hovered_interactable = new_hovered_interactable;
+                Fate::Live
             }
-            Fate::Live
         }
-    }}
+    }
+}
+
+#[derive(Copy, Clone)]
+struct UIUpdate;
+
+impl Recipient<UIUpdate> for UserInterface {
+    fn receive(&mut self, msg: &UIUpdate) -> Fate {
+        for mouse_action in &self.input_state.mouse.clone() {
+            match *mouse_action {
+                Mouse::Moved(position) => {
+                    let delta = self.cursor_2d - position;
+                    if self.input_state.rotate_mod {
+                        Renderer::id() << MoveEye { scene_id: 0, movement: ::monet::Movement::Rotate(-delta.x / 300.0) };
+                        self.cursor_2d = position;
+                    } else if self.input_state.pan_mod {
+                        Renderer::id() << MoveEye { scene_id: 0, movement: ::monet::Movement::Shift(V3::new(-delta.y / 3.0, delta.x / 3.0, 0.0)) };
+                        self.cursor_2d = position;
+                    } else {
+                        self.cursor_2d = position;
+                        Renderer::id() << Project2dTo3d {
+                            scene_id: 0,
+                            position_2d: position,
+                            requester: Self::id()
+                        };
+                    }
+                },
+                Mouse::Scrolled(delta) => {
+                    Renderer::id() << MoveEye{scene_id: 0, movement: ::monet::Movement::Zoom(delta.y)};
+                },
+                Mouse::Down(MouseButton::Left) => {
+                    self.drag_start_2d = Some(self.cursor_2d);
+                    self.drag_start_3d = Some(self.cursor_3d);
+                    let cursor_3d = self.cursor_3d;
+                    self.receive(&Projected3d { position_3d: cursor_3d });
+                    self.active_interactable = self.hovered_interactable;
+                    if let Some(active_interactable) = self.active_interactable {
+                        active_interactable << Event3d::DragStarted { at: self.cursor_3d };
+                    }
+                },
+                Mouse::Up(MouseButton::Left) => {
+                    if let Some(active_interactable) = self.active_interactable {
+                        active_interactable << Event3d::DragFinished {
+                            from: self.drag_start_3d.expect("active interactable but no drag start"),
+                            to: self.cursor_3d
+                        };
+                    }
+                    self.drag_start_2d = None;
+                    self.drag_start_3d = None;
+                    self.active_interactable = None;
+                },
+                _ => ()
+            }
+        }
+        if self.input_state.forward {
+            Renderer::id() << MoveEye { scene_id: 0, movement: ::monet::Movement::Shift(V3::new(5.0, 0.0, 0.0))};
+        }
+        if self.input_state.backward {
+            Renderer::id() << MoveEye { scene_id: 0, movement: ::monet::Movement::Shift(V3::new(-5.0, 0.0, 0.0))};
+        }
+        if self.input_state.left {
+            Renderer::id() << MoveEye { scene_id: 0, movement: ::monet::Movement::Shift(V3::new(0.0, -5.0, 0.0))};
+        }
+        if self.input_state.right {
+            Renderer::id() << MoveEye { scene_id: 0, movement: ::monet::Movement::Shift(V3::new(0.0, 5.0, 0.0))};
+        }
+
+        self.input_state.mouse.clear();
+        Fate::Live
+    }
 }
 
 pub fn setup_window_and_renderer(system: &mut ActorSystem, renderables: Vec<ID>) -> GlutinFacade {
@@ -237,6 +349,7 @@ pub fn setup_window_and_renderer(system: &mut ActorSystem, renderables: Vec<ID>)
     system.add_inbox::<Focus, UserInterface>();
     system.add_unclearable_inbox::<Mouse, UserInterface>();
     system.add_unclearable_inbox::<Key, UserInterface>();
+    system.add_unclearable_inbox::<UIUpdate, UserInterface>();
     system.add_unclearable_inbox::<Projected3d, UserInterface>();
 
     let mut renderer = Renderer::new(window.clone());
@@ -251,29 +364,21 @@ pub fn setup_window_and_renderer(system: &mut ActorSystem, renderables: Vec<ID>)
 }
 
 pub fn process_events(window: &GlutinFacade) -> bool {
-    let mut cleaned_events = window.poll_events().collect::<Vec<_>>();
-    if let Some(last_mouse_move_event_pos) = cleaned_events.iter().rposition(|event| match *event { Event::MouseMoved(..) => true, _ => false}) {
-        let mut i = 0;
-        cleaned_events.retain(|event| {
-            let keep = match *event {
-                Event::MouseMoved(..) => i == last_mouse_move_event_pos,
-                _ => true
-            };
-            i += 1;
-            keep
-        });
-    }
-    for event in cleaned_events {
+    for event in window.poll_events().collect::<Vec<_>>() {
         match event {
             Event::Closed => return false,
-            Event::MouseWheel(MouseScrollDelta::PixelDelta(x, y), _) =>
-                UserInterface::id() << Mouse::Scrolled(P2::new(x as N, y as N)),
+            Event::MouseWheel(delta, _) => {
+                UserInterface::id() << Mouse::Scrolled(match delta{
+                    MouseScrollDelta::LineDelta(x, y) => P2::new(x * 50 as N, y * 50 as N),
+                    MouseScrollDelta::PixelDelta(x, y) => P2::new(x as N, y as N)
+                })
+            },
             Event::MouseMoved(x, y) =>
                 UserInterface::id() << Mouse::Moved(P2::new(x as N, y as N)),
-            Event::MouseInput(ElementState::Pressed, MouseButton::Left) =>
-                UserInterface::id() << Mouse::Down,
-            Event::MouseInput(ElementState::Released, MouseButton::Left) =>
-                UserInterface::id() << Mouse::Up,
+            Event::MouseInput(ElementState::Pressed, button) =>
+                UserInterface::id() << Mouse::Down(button),
+            Event::MouseInput(ElementState::Released, button) =>
+                UserInterface::id() << Mouse::Up(button),
             Event::KeyboardInput(ElementState::Pressed, _, Some(key_code)) =>
                 UserInterface::id() << Key::Down(key_code),
             Event::KeyboardInput(ElementState::Released, _, Some(key_code)) =>
@@ -281,5 +386,6 @@ pub fn process_events(window: &GlutinFacade) -> bool {
             _ => {}
         }
     }
+    UserInterface::id() << UIUpdate {};
     true
 }

--- a/src/core/ui.rs
+++ b/src/core/ui.rs
@@ -319,12 +319,18 @@ impl Recipient<UIUpdate> for UserInterface {
         for mouse_action in &self.input_state.mouse.clone() {
             match *mouse_action {
                 Mouse::Moved(position) => {
+                    let inverted = if self.settings.invert_y {-1.0} else {1.0};
                     let delta = self.cursor_2d - position;
                     if self.input_state.rotate_mod {
-                        Renderer::id() << MoveEye { scene_id: 0, movement: ::monet::Movement::Rotate(-delta.x * self.settings.rotation_speed / 300.0) };
+                        Renderer::id() << MoveEye { scene_id: 0, movement: ::monet::Movement::Rotate(
+                            -delta.x * self.settings.rotation_speed * inverted/ 300.0)
+                        };
                         self.cursor_2d = position;
                     } else if self.input_state.pan_mod {
-                        Renderer::id() << MoveEye { scene_id: 0, movement: ::monet::Movement::Shift(V3::new(-delta.y * self.settings.move_speed / 3.0, delta.x * self.settings.move_speed / 3.0, 0.0)) };
+                        Renderer::id() << MoveEye { scene_id: 0, movement: ::monet::Movement::Shift(
+                            V3::new(-delta.y * self.settings.move_speed * inverted/ 3.0,
+                                    delta.x * self.settings.move_speed * inverted / 3.0, 0.0)
+                        )};
                         self.cursor_2d = position;
                     } else {
                         self.cursor_2d = position;

--- a/src/core/ui.rs
+++ b/src/core/ui.rs
@@ -314,6 +314,7 @@ impl Recipient<Projected3d> for UserInterface {
 #[derive(Copy, Clone)]
 struct UIUpdate;
 
+#[allow(unused_variables)]
 impl Recipient<UIUpdate> for UserInterface {
     fn receive(&mut self, msg: &UIUpdate) -> Fate {
         for mouse_action in &self.input_state.mouse.clone() {

--- a/src/core/ui.rs
+++ b/src/core/ui.rs
@@ -314,9 +314,8 @@ impl Recipient<Projected3d> for UserInterface {
 #[derive(Copy, Clone)]
 struct UIUpdate;
 
-#[allow(unused_variables)]
 impl Recipient<UIUpdate> for UserInterface {
-    fn receive(&mut self, msg: &UIUpdate) -> Fate {
+    fn receive(&mut self, _msg: &UIUpdate) -> Fate {
         for mouse_action in &self.input_state.mouse.clone() {
             match *mouse_action {
                 Mouse::Moved(position) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
-#![feature(custom_derive, plugin, rustc_macro, proc_macro, conservative_impl_trait)]
+#![feature(custom_derive, plugin, proc_macro, conservative_impl_trait)]
+#![plugin(clippy)]
 #![allow(dead_code)]
 #![allow(no_effect, unnecessary_operation)]
 // Enable this for memory tracking with Instruments/MacOS
@@ -33,9 +34,6 @@ use game::lanes_and_cars::lane_rendering::{LaneAsphalt, LaneMarker, TransferLane
 use game::lanes_and_cars::lane_thing_collector::ThingCollector;
 use game::lanes_and_cars::planning::{CurrentPlan};
 use kay::Individual;
-
-use serde::ser::Serialize;
-use serde::de::Deserialize;
 
 const SECONDS_PER_TICK : f32 = 1.0 / 20.0;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,5 @@
-#![feature(custom_derive, plugin)]
-#![cfg_attr(feature = "serde_derive", feature(proc_macro))]
-#![feature(proc_macro)]
+#![feature(custom_derive, plugin, rustc_macro, proc_macro, conservative_impl_trait)]
 #![allow(dead_code)]
-#![feature(plugin)]
-#![feature(conservative_impl_trait)]
 #![allow(no_effect, unnecessary_operation)]
 // Enable this for memory tracking with Instruments/MacOS
 // and for much better stacktraces for memory issues
@@ -16,7 +12,6 @@ extern crate random;
 extern crate fnv;
 extern crate roaring;
 extern crate open;
-#[cfg(feature = "serde_derive")]
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_json;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,9 @@
+#![feature(custom_derive, plugin)]
+#![cfg_attr(feature = "serde_derive", feature(proc_macro))]
 #![feature(proc_macro)]
 #![allow(dead_code)]
 #![feature(plugin)]
 #![feature(conservative_impl_trait)]
-#![plugin(clippy)]
 #![allow(no_effect, unnecessary_operation)]
 // Enable this for memory tracking with Instruments/MacOS
 // and for much better stacktraces for memory issues
@@ -15,6 +16,11 @@ extern crate random;
 extern crate fnv;
 extern crate roaring;
 extern crate open;
+#[cfg(feature = "serde_derive")]
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
+extern crate serde;
 
 extern crate kay;
 #[macro_use]
@@ -32,6 +38,9 @@ use game::lanes_and_cars::lane_rendering::{LaneAsphalt, LaneMarker, TransferLane
 use game::lanes_and_cars::lane_thing_collector::ThingCollector;
 use game::lanes_and_cars::planning::{CurrentPlan};
 use kay::Individual;
+
+use serde::ser::Serialize;
+use serde::de::Deserialize;
 
 const SECONDS_PER_TICK : f32 = 1.0 / 20.0;
 


### PR DESCRIPTION
Sorry if I'm treading on your toes, but I saw some comments on Reddit complaining about the UI and controls, so I changed the camera controls to feel more natural for me, to be more of an RTS style. New controls are:

- WASD or shift + mouse move to pan
- middle click + drag to rotate
- Scroll to zoom (also, scroll events were not being fired before for me in Linux because I think Linux uses MouseScrollDelta::LineDelta instead of MouseScrollDelta::PixelDelta, so I updated the code handling that so both should work now, untested in Windows or Mac)

Also, as theoretically what keyboard and mouse events do can be changed by the current keys and buttons held down, I updated the input handling so the Key and Mouse events mutate the InputState struct in UserInterface, and the actual update is performed when an UIUpdate message is received, after all the input is stored into InputState.

Ben Wang