### PR TITLE
Add license to Cargo manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "citybound"
 version = "0.1.0"
 authors = ["Anselm Eickhoff <anselm.eickhoff@gmail.com>"]
+license = "AGPL-3.0"
 
 [dependencies]
 ordered-float = "0.2.3"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Recommended setup:
 
 # License
 
-Citybound is licensed under AGPL (see LICENSE.txt), for interest in commercial licenses please contact me.
+Citybound is licensed under AGPL (see [LICENSE.txt](LICENSE.txt)), for interest in commercial licenses please contact me.
 
 # Contribution
 


### PR DESCRIPTION
\+ Link to license in README

Accidentally opened this on another fork last night :sweat: