### PR TITLE
Change rustup default to override

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@ Find out more about Citybound [on the wiki](https://github.com/aeickhoff/citybou
 Currently Citybound is only tested with Rust `nightly-2016-10-28`
 
 Recommended setup:
-* install rustup
-* Windows: `rustup default nightly-2016-10-28-x86_64-pc-windows-gnu`
-* MacOS: `rustup default nightly-2016-10-28-x86_64-apple-darwin`
-* Linux: `rustup default nightly-2016-10-28-x86_64-unknown-linux-gnu`
+* install [rustup](https://rustup.rs/)
+* `git clone https://github.com/citybound/citybound.git`
+* `cd citybound`
+* Windows: `rustup override add nightly-2016-10-28-x86_64-pc-windows-gnu`
+* MacOS: `rustup override add nightly-2016-10-28-x86_64-apple-darwin`
+* Linux: `rustup override add nightly-2016-10-28-x86_64-unknown-linux-gnu`
 * `cargo run --release` (Debug mode is generally too slow to interact with)
 
 # License


### PR DESCRIPTION
Hi @aeickhoff!

I'd suggest using `rustup override` instead of `rustup default` for building, as using default will set the rust version globally whereas override just sets it for specific directories.

I've made a PR as a suggestion for using override in the README.

Great project and keep up the good work :smile: