### PR TITLE
Fix a link and a typo in kay documentation

### DIFF
--- a/lib/kay/src/lib.rs
+++ b/lib/kay/src/lib.rs
@@ -4,7 +4,7 @@
 //! otherwise completely isloated from each other. Actors can only mutate their own state.
 //!
 //! Have a look at [`Actor`](trait.Actor.html), [`Recipient`](trait.Recipient.html)
-//! and [`Swarm`](struct.Swarm.html) to understand the main abstractions.
+//! and [`Swarm`](swarm/struct.Swarm.html) to understand the main abstractions.
 
 #![warn(missing_docs)]
 #![feature(plugin)]

--- a/lib/kay/src/messaging.rs
+++ b/lib/kay/src/messaging.rs
@@ -4,7 +4,7 @@ use super::compact::Compact;
 /// Return type of message handling functions, signifying if
 /// an `Actor`/`SubActor` should live on after receiving a certain message type.
 ///
-/// Note: so far only has an affect on `SubActor`s in `Swarm`s
+/// Note: so far only has an effect on `SubActor`s in `Swarm`s
 pub enum Fate {
     /// Means: the `Actor`/`SubActor` should live on
     Live,


### PR DESCRIPTION
Just two tiny fixes for errors I've spotted while reading the documentation of kay.