### PR TITLE
Change pitch and yaw keybinds from '*Alt' to '*Menu'

### DIFF
--- a/src/core/settings.rs
+++ b/src/core/settings.rs
@@ -48,11 +48,11 @@ impl Settings {
             pan_modifier_key: vec![KeyOrButton::Key(VirtualKeyCode::LShift),
                                    KeyOrButton::Key(VirtualKeyCode::RShift)],
             yaw_modifier_key: vec![KeyOrButton::Button(MouseButton::Middle),
-                                   KeyOrButton::Key(VirtualKeyCode::LAlt),
-                                   KeyOrButton::Key(VirtualKeyCode::RAlt)],
+                                   KeyOrButton::Key(VirtualKeyCode::LMenu),
+                                   KeyOrButton::Key(VirtualKeyCode::RMenu)],
             pitch_modifier_key: vec![KeyOrButton::Button(MouseButton::Middle),
-                                     KeyOrButton::Key(VirtualKeyCode::LAlt),
-                                     KeyOrButton::Key(VirtualKeyCode::RAlt)],
+                                     KeyOrButton::Key(VirtualKeyCode::LMenu),
+                                     KeyOrButton::Key(VirtualKeyCode::RMenu)],
         }
     }
 


### PR DESCRIPTION
There is still a problem with `LControl` being reported alongside `RMenu` keypresses. Fixing that is outside the scope of this pull request.

I can't check if this works on all platforms, or Windows only.