### PR TITLE
Revert "Make the workaround slightly less horrible #108 #119", fixes #162

### DIFF
--- a/src/game/lanes_and_cars/planning/plan_result_steps.rs
+++ b/src/game/lanes_and_cars/planning/plan_result_steps.rs
@@ -46,7 +46,7 @@ pub fn find_intersections(strokes: &CVec<LaneStroke>) -> CVec<Intersection> {
 }
 
 // TODO: this is obviously only a workaround
-const MAX_STROKE_LENGTH_FOR_GRID_ACCELERATOR: N = 100000.0;
+const MAX_STROKE_LENGTH_FOR_GRID_ACCELERATOR: N = 10000.0;
 
 use core::grid_accelerator::GridAccelerator;
 


### PR DESCRIPTION
Fixes #162

This reverts commit ee8b08a086c35fb3e9d1361e38e3e79b2b47f671.

Reversing this commit removes the bug, but I don't know enough about the
game engine to explain why.  My *guess* would be that 100,000 > 2^16,
and monet uses a lot of u16s to store values.