### PR TITLE
Improve actor economics & make kay less magic

### DIFF
--- a/ci/docs.sh
+++ b/ci/docs.sh
@@ -4,8 +4,11 @@ then
     cargo doc --package chunked --no-deps
     cargo doc --package compact --no-deps
     cargo doc --package compact_macros --no-deps
+    cargo doc --package descartes --no-deps
     cargo doc --package kay --no-deps
     cargo doc --package kay_macros --no-deps
+    cargo doc --package monet --no-deps
+    cargo doc --package stagemaster --no-deps
     echo '<meta http-equiv=refresh content=0;url=kay/index.html>' > target/doc/index.html
     sudo pip install ghp-import
     ghp-import -n target/doc

--- a/lib/descartes/src/intersect.rs
+++ b/lib/descartes/src/intersect.rs
@@ -156,11 +156,10 @@ impl<'a> Intersect for (&'a Segment, &'a Segment) {
                         .intersect()
                         .iter()
                         .filter(|intersection| {
-                                    intersection.along_a >= 0.0 &&
-                                    intersection.along_a <= a.length() &&
-                                    intersection.along_b >= 0.0 &&
-                                    intersection.along_b <= b.length()
-                                })
+                            intersection.along_a >= 0.0 && intersection.along_a <= a.length() &&
+                            intersection.along_b >= 0.0 &&
+                            intersection.along_b <= b.length()
+                        })
                         .cloned()
                         .collect()
             }
@@ -169,23 +168,19 @@ impl<'a> Intersect for (&'a Segment, &'a Segment) {
                       start: a.start(),
                       direction: a.start_direction(),
                   },
-                 &Circle {
-                      center: b.center(),
-                      radius: b.radius(),
-                  })
+                 &Circle { center: b.center(), radius: b.radius() })
                         .intersect()
                         .iter()
                         .filter(|intersection| {
-                                    intersection.along_a >= 0.0 &&
-                                    intersection.along_a <= a.length() &&
-                                    b.includes(intersection.position)
-                                })
+                            intersection.along_a >= 0.0 && intersection.along_a <= a.length() &&
+                            b.includes(intersection.position)
+                        })
                         .map(|intersection| {
-                                 Intersection {
-                                     along_b: b.project(intersection.position).unwrap(),
-                                     ..*intersection
-                                 }
-                             })
+                            Intersection {
+                                along_b: b.project(intersection.position).unwrap(),
+                                ..*intersection
+                            }
+                        })
                         .collect()
             }
             (false, true) => {
@@ -196,27 +191,20 @@ impl<'a> Intersect for (&'a Segment, &'a Segment) {
                     .collect()
             }
             (false, false) => {
-                (&Circle {
-                      center: a.center(),
-                      radius: a.radius(),
-                  },
-                 &Circle {
-                      center: b.center(),
-                      radius: b.radius(),
-                  })
+                (&Circle { center: a.center(), radius: a.radius() },
+                 &Circle { center: b.center(), radius: b.radius() })
                         .intersect()
                         .iter()
                         .filter(|intersection| {
-                                    a.includes(intersection.position) &&
-                                    b.includes(intersection.position)
-                                })
+                            a.includes(intersection.position) && b.includes(intersection.position)
+                        })
                         .map(|intersection| {
-                                 Intersection {
-                                     along_a: a.project(intersection.position).unwrap(),
-                                     along_b: b.project(intersection.position).unwrap(),
-                                     ..*intersection
-                                 }
-                             })
+                            Intersection {
+                                along_a: a.project(intersection.position).unwrap(),
+                                along_b: b.project(intersection.position).unwrap(),
+                                ..*intersection
+                            }
+                        })
                         .collect()
             }
         }
@@ -233,10 +221,10 @@ impl<'a, P: Path> Intersect for (&'a P, &'a P) {
                     let identical_to_previous = intersection_list
                         .iter()
                         .any(|previous_intersection| {
-                                 (previous_intersection as &Intersection)
-                                     .position
-                                     .is_roughly_within(intersection.position, THICKNESS)
-                             });
+                            (previous_intersection as &Intersection)
+                                .position
+                                .is_roughly_within(intersection.position, THICKNESS)
+                        });
                     if !identical_to_previous {
                         intersection_list.push(Intersection {
                                                    along_a: intersection.along_a + offset_a,

--- a/lib/descartes/src/path.rs
+++ b/lib/descartes/src/path.rs
@@ -197,11 +197,11 @@ impl<T: Path> Curve for T {
     fn project_with_tolerance(&self, point: P2, tolerance: N) -> Option<N> {
         self.segments_with_start_offsets()
             .filter_map(|pair: (&Segment, N)| {
-                            let (segment, start_offset) = pair;
-                            segment
-                                .project_with_tolerance(point, tolerance)
-                                .map(|offset| offset + start_offset)
-                        })
+                let (segment, start_offset) = pair;
+                segment
+                    .project_with_tolerance(point, tolerance)
+                    .map(|offset| offset + start_offset)
+            })
             .min_by_key(|offset| OrderedFloat((self.along(*offset) - point).norm()))
     }
 

--- a/lib/descartes/src/primitives.rs
+++ b/lib/descartes/src/primitives.rs
@@ -101,14 +101,8 @@ impl Segment {
         } else if (end - start).norm() < MAX_SIMPLE_LINE_LENGTH {
             vec![Segment::line(start, end)]
         } else {
-            let maybe_linear_intersection = (&Line {
-                                                  start: start,
-                                                  direction: start_direction,
-                                              },
-                                             &Line {
-                                                  start: end,
-                                                  direction: -end_direction,
-                                              })
+            let maybe_linear_intersection = (&Line { start: start, direction: start_direction },
+                                             &Line { start: end, direction: -end_direction })
                     .intersect()
                     .into_iter()
                     .next()

--- a/lib/descartes/src/shapes.rs
+++ b/lib/descartes/src/shapes.rs
@@ -16,10 +16,7 @@ pub struct Band<P: Path> {
 
 impl<P: Path> Band<P> {
     pub fn new(path: P, width: N) -> Band<P> {
-        Band {
-            path: path,
-            width: width,
-        }
+        Band { path: path, width: width }
     }
 
     pub fn outline(&self) -> P {

--- a/lib/kay/src/id.rs
+++ b/lib/kay/src/id.rs
@@ -33,6 +33,9 @@ impl ID {
         }
     }
 
+    /// Get a version of an actor ID that signals that a message
+    /// should be delivered to all sub-actors of that actor,
+    /// like in the case of a [`Swarm`](swarm/struct.Swarm.html).
     pub fn broadcast(&self) -> ID {
         ID {
             sub_actor_id: broadcast_sub_actor_id(),

--- a/lib/kay/src/id.rs
+++ b/lib/kay/src/id.rs
@@ -1,5 +1,3 @@
-use super::THE_SYSTEM;
-use super::messaging::Message;
 use super::type_registry::ShortTypeId;
 
 /// An ID that uniquely identifies an `Actor`, or even a `SubActor` within a `Swarm`
@@ -20,6 +18,10 @@ pub struct ID {
     pub sub_actor_id: u32,
 }
 
+pub fn broadcast_sub_actor_id() -> u32 {
+    u32::max_value()
+}
+
 impl ID {
     /// Create a new ID
     pub fn new(type_id: ShortTypeId, sub_actor_id: u32, version: u8) -> Self {
@@ -28,6 +30,13 @@ impl ID {
             machine: 0,
             version: version,
             sub_actor_id: sub_actor_id,
+        }
+    }
+
+    pub fn broadcast(&self) -> ID {
+        ID {
+            sub_actor_id: broadcast_sub_actor_id(),
+            ..*self
         }
     }
 }
@@ -39,20 +48,5 @@ impl ::std::fmt::Debug for ID {
                *(self.type_id),
                self.version,
                self.sub_actor_id)
-    }
-}
-
-/// The `<<` operator is overloaded as the main way of sending messages
-/// to an `Actor` identified by an ID:
-///
-/// ```
-///    some_actor_id << SomeMessage{...};
-/// ```
-impl<M: Message> ::std::ops::Shl<M> for ID {
-    type Output = ();
-    fn shl(self, rhs: M) {
-        unsafe {
-            (*THE_SYSTEM).send(self, rhs);
-        }
     }
 }

--- a/lib/kay/src/lib.rs
+++ b/lib/kay/src/lib.rs
@@ -32,6 +32,6 @@ mod type_registry;
 mod id;
 mod actor_system;
 
-pub use self::messaging::{Message, Packet, Recipient, Fate};
+pub use self::messaging::{Message, Packet, Fate};
 pub use self::id::ID;
-pub use self::actor_system::{THE_SYSTEM, ActorSystem, Actor};
+pub use self::actor_system::{ActorSystem, World};

--- a/lib/kay/src/lib.rs
+++ b/lib/kay/src/lib.rs
@@ -3,7 +3,8 @@
 //! In `Kay`, actors concurrently send and receive asynchronous messages, but are
 //! otherwise completely isloated from each other. Actors can only mutate their own state.
 //!
-//! Have a look at [`Actor`](trait.Actor.html), [`Recipient`](trait.Recipient.html)
+//! Have a look at [`ActorSystem`](struct.ActorSystem.html),
+//! [`ActorDefiner`](struct.ActorDefiner.html), [`World`](struct.World.html)
 //! and [`Swarm`](swarm/struct.Swarm.html) to understand the main abstractions.
 
 #![warn(missing_docs)]
@@ -34,4 +35,4 @@ mod actor_system;
 
 pub use self::messaging::{Message, Packet, Fate};
 pub use self::id::ID;
-pub use self::actor_system::{ActorSystem, World};
+pub use self::actor_system::{ActorSystem, ActorDefiner, World};

--- a/lib/kay/src/messaging.rs
+++ b/lib/kay/src/messaging.rs
@@ -12,23 +12,6 @@ pub enum Fate {
     Die,
 }
 
-/// Trait with which message handling for `Actor`/`SubActor`s is implemented
-pub trait Recipient<M: Message> {
-    /// Let's an actor mutate its state when it gets a message,
-    /// send messages to other actors and determine its new `Fate`
-    fn receive(&mut self, _message: &M) -> Fate {
-        unimplemented!()
-    }
-    /// Like `receive`, but allows access to `packet.recipient_id`
-    /// that the packet/message was sent to. This is used by `Swarm`
-    /// to dispatch the message to the correct `SubActor`.
-    ///
-    /// The default implementation just calls `receive` with `packet.message`
-    fn receive_packet(&mut self, packet: &Packet<M>) -> Fate {
-        self.receive(&packet.message)
-    }
-}
-
 /// Trait that a datastructure must implement in order
 /// to be sent and received as a message.
 ///

--- a/lib/kay/src/slot_map.rs
+++ b/lib/kay/src/slot_map.rs
@@ -8,10 +8,7 @@ pub struct SlotIndices {
 
 impl SlotIndices {
     pub fn new(bin: usize, slot: usize) -> SlotIndices {
-        SlotIndices {
-            bin: bin as u8,
-            slot: slot as u32,
-        }
+        SlotIndices { bin: bin as u8, slot: slot as u32 }
     }
 
     pub fn invalid() -> SlotIndices {

--- a/lib/kay/src/swarm.rs
+++ b/lib/kay/src/swarm.rs
@@ -3,9 +3,9 @@
 use super::chunked::{MemChunker, ValueInChunk, SizedChunkedArena, MultiSized};
 use super::compact::Compact;
 use super::slot_map::{SlotIndices, SlotMap};
-use super::messaging::{Recipient, Message, Packet, Fate};
-use super::actor_system::Actor;
-use super::id::ID;
+use super::messaging::{Message, Packet, Fate};
+use super::actor_system::{World, ActorDefiner};
+use super::id::{ID, broadcast_sub_actor_id};
 use std::marker::PhantomData;
 use std::mem::size_of;
 
@@ -33,10 +33,6 @@ pub trait SubActor: Compact + StorageAware + 'static {
     fn id(&self) -> ID;
     /// Set the full ID (Swarm type id + sub-actor id) of `self` (called internally by `Swarm`)
     unsafe fn set_id(&mut self, id: ID);
-}
-
-fn broadcast_sub_actor_id() -> u32 {
-    u32::max_value()
 }
 
 /// Offers efficient storage and updating of large numbers of identical `SubActor`s
@@ -83,11 +79,9 @@ impl<SA: SubActor> Swarm<SA> {
         self.at_index_mut(index)
     }
 
-    fn add(&mut self, initial_state: &SA) -> ID {
+    fn add(&mut self, initial_state: &SA, base_id: ID) -> ID {
         let (sub_actor_id, version) = self.allocate_sub_actor_id();
-        let id = ID::new(unsafe { (*super::THE_SYSTEM).short_id::<Self>() },
-                         sub_actor_id as u32,
-                         version as u8);
+        let id = ID::new(base_id.type_id, sub_actor_id as u32, version as u8);
         self.add_with_id(initial_state, id);
         *self.n_sub_actors += 1;
         id
@@ -151,15 +145,18 @@ impl<SA: SubActor> Swarm<SA> {
         self.swap_remove(old_i)
     }
 
-    fn receive_instance<M: Message>(&mut self, packet: &Packet<M>)
-        where SA: Recipient<M>
+    fn receive_instance<M: Message, H>(&mut self,
+                                       packet: &Packet<M>,
+                                       handler: &H,
+                                       world: &mut World)
+        where H: Fn(&Packet<M>, &mut SA, &mut World) -> Fate + 'static
     {
         let (fate, is_still_compact) = {
             let actor = self.at_mut(packet
                                         .recipient_id
                                         .expect("Recipient ID not set")
                                         .sub_actor_id as usize);
-            let fate = actor.receive_packet(packet);
+            let fate = handler(packet, actor, world);
             (fate, actor.is_still_compact())
         };
 
@@ -176,8 +173,11 @@ impl<SA: SubActor> Swarm<SA> {
         }
     }
 
-    fn receive_broadcast<M: Message>(&mut self, packet: &Packet<M>)
-        where SA: Recipient<M>
+    fn receive_broadcast<M: Message, H>(&mut self,
+                                        packet: &Packet<M>,
+                                        handler: &H,
+                                        world: &mut World)
+        where H: Fn(&Packet<M>, &mut SA, &mut World) -> Fate + 'static
     {
         // this function has to deal with the fact that during the iteration,
         // receivers of the broadcast can be resized
@@ -206,7 +206,7 @@ impl<SA: SubActor> Swarm<SA> {
                 let index = SlotIndices::new(c, slot);
                 let (fate, is_still_compact, id) = {
                     let actor = self.at_index_mut(index);
-                    let fate = actor.receive_packet(packet);
+                    let fate = handler(packet, actor, world);
                     (fate, actor.is_still_compact(), actor.id())
                 };
 
@@ -250,138 +250,39 @@ impl<SA: SubActor> Swarm<SA> {
         }
     }
 
-    /// Get an ID that refers to all sub-actors inside a `Swarm`.
-    /// If you send a message to this ID, all sub-actors will receive it
-    /// (Exception: the Swarm handles the message itself, see
-    /// [`RecipientAsSwarm`](trait.RecipientAsSwarm.html))
-    pub fn all() -> ID
-        where Self: Sized
-    {
-        ID::new(unsafe { (*super::THE_SYSTEM).short_id::<Self>() },
-                broadcast_sub_actor_id(),
-                0)
-    }
-}
-
-impl<SA: SubActor> Default for Swarm<SA> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-/// A `Swarm` is itself an `Actor`!
-impl<SA: SubActor> Actor for Swarm<SA> {}
-
-/// Helper trait for dispatching messages either to `SubActor`s of a `Swarm` or the `Swarm` itself.
-///
-/// By implementing this trait on a `SubActor`, you indirectly control
-/// what `Swarm<SubActor>` will be a `Recipient` of.
-/// *This is required since you can't implement `Recipient` on `Swarm` yourself,
-/// both being foreign types.*
-///
-/// The default implementation will make `Swarm<SubActor>` a `Recipient<Message>` for all messages
-/// that `SubActor` is a `Recipient` of, dispatching incoming messages to the correct sub-actor
-/// based on the sub-actor id part of the `Packet`'s recipient field.
-///
-/// To override this behaviour and handle all messages of a certain type on the Swarm level,
-/// you can implement `RecipientAsSwarm<MessageForSwarm>` for `SubActor` yourself.
-///
-/// Further, already given implementations define how a `Swarm` handles
-/// `RequestConfirmation`, `ToRandom`, `Create` and `CreateWith` messages.
-pub trait RecipientAsSwarm<M: Message>: Sized {
-    /// Analogous to [`Recipient::receive`](trait.Recipient.html#method.receive)
-    fn receive(_swarm: &mut Swarm<Self>, _message: &M) -> Fate {
-        unimplemented!()
-    }
-    /// Analogous to [`Recipient::receive_packet`](trait.Recipient.html#method.receive_packet)
-    fn receive_packet(swarm: &mut Swarm<Self>, packet: &Packet<M>) -> Fate {
-        Self::receive(swarm, &packet.message)
-    }
-}
-
-/// See [`RecipientAsSwarm`](trait.RecipientAsSwarm.html)
-impl<M: Message, SA: SubActor + RecipientAsSwarm<M>> Recipient<M> for Swarm<SA> {
-    fn receive_packet(&mut self, packet: &Packet<M>) -> Fate {
-        SA::receive_packet(self, packet)
-    }
-}
-
-/// Default implementation that redirects messages to sub-actors
-impl<M: Message + NotACreateMessage + NotARequestConfirmationMessage + NotAToRandomMessage,
-     SA: SubActor + Recipient<M>> RecipientAsSwarm<M>
-    for SA {
-    fn receive_packet(swarm: &mut Swarm<SA>, packet: &Packet<M>) -> Fate {
-        if packet
-               .recipient_id
-               .expect("Recipient ID not set")
-               .sub_actor_id == broadcast_sub_actor_id() {
-            swarm.receive_broadcast(packet);
-        } else {
-            swarm.receive_instance(packet);
+    pub fn subactors<S: Fn(SubActorDefiner<SA>) + 'static>(subactor_definition: S)
+                                                           -> impl Fn(ActorDefiner<Self>) {
+        move |mut the_swarm| {
+            Self::define_control_handlers(&mut the_swarm);
+            subactor_definition(SubActorDefiner(the_swarm));
         }
-        Fate::Live
+    }
+
+    fn define_control_handlers<'a>(the_swarm: &mut ActorDefiner<'a, Self>) {
+        let swarm_id = the_swarm.world().id::<Self>();
+        the_swarm.on(move |&Create(ref initial_state), swarm, _| {
+            swarm.add(initial_state, swarm_id);
+            Fate::Live
+        });
     }
 }
 
-/// A wrapper for messages to request a confirmation about message receival.
-///
-/// The receiving `Swarm` will reply to `requester` with a
-/// [`Confirmation`](struct.Confirmation.html).
-///
-/// This is typically used to make sure that all sub-actors
-/// of a certain kind received and handled a message.
+/// A message for adding a new sub-actor to a `Swarm` given its initial state.
 ///
 /// Note: although the handler is implemented in `Swarm`, you need to call
-/// `Swarm::<SubActor>::handle::<RequestConfirmation<Message>>();`
-/// to actually register the handler (for each message type that should be confirmable).
+/// `Swarm::<SubActor>::handle::<Create<SubActor>>();`
+/// to actually register the handler for creating sub-actors like this.
 #[derive(Compact, Clone)]
-pub struct RequestConfirmation<M: Message> {
-    /// Who should the `Confirmation` reply be sent to?
-    pub requester: ID,
-    /// Actual message that should be handled
-    pub message: M,
-}
+pub struct Create<SA: SubActor>(pub SA);
 
-#[doc(hidden)]
-pub trait NotARequestConfirmationMessage {}
-impl NotARequestConfirmationMessage for .. {}
-impl<M: Message> !NotARequestConfirmationMessage for RequestConfirmation<M> {}
-
-
-/// The reply to a [`RequestConfirmation`](struct.RequestConfirmation.html)
-#[derive(Clone)]
-pub struct Confirmation<M: Message> {
-    /// How many sub-actors actually received and handled the message
-    pub n_recipients: usize,
-    _marker: PhantomData<*const M>,
-}
-
-impl<M: Message> Copy for Confirmation<M> {}
-
-impl<M: Message, SA: SubActor + RecipientAsSwarm<M>> RecipientAsSwarm<RequestConfirmation<M>>
-    for SA {
-    fn receive_packet(swarm: &mut Swarm<SA>, packet: &Packet<RequestConfirmation<M>>) -> Fate {
-        let n_recipients = if packet
-               .recipient_id
-               .expect("Recipient ID not set")
-               .sub_actor_id == broadcast_sub_actor_id() {
-            *swarm.n_sub_actors
-        } else {
-            1
-        };
-        let fate = SA::receive_packet(swarm,
-                                      &Packet {
-                                           recipient_id: packet.recipient_id,
-                                           message: packet.message.message.clone(),
-                                       });
-        packet.message.requester <<
-        Confirmation::<M> {
-            n_recipients: n_recipients,
-            _marker: PhantomData,
-        };
-        fate
-    }
-}
+/// A message for adding a new sub-actor to a `Swarm` given its initial state
+/// and an initial message that the sub-actor will handle immediately after creation.
+///
+/// Note: although the handler is implemented in `Swarm`, you need to call
+/// `Swarm::<SubActor>::handle::<CreateWith<SubActor, Message>>();`
+/// to actually register the handler for creating sub-actors like this.
+#[derive(Compact, Clone)]
+pub struct CreateWith<SA: SubActor, M: Message>(pub SA, pub M);
 
 /// A wrapper for messages to send a message to random sub-actors.
 ///
@@ -396,78 +297,89 @@ pub struct ToRandom<M: Message> {
     pub n_recipients: usize,
 }
 
-#[doc(hidden)]
-pub trait NotAToRandomMessage {}
-impl NotAToRandomMessage for .. {}
-impl<M: Message> !NotAToRandomMessage for ToRandom<M> {}
+pub struct SubActorDefiner<'a, SA: 'static>(ActorDefiner<'a, Swarm<SA>>);
 
-impl<M: Message, SA: SubActor + RecipientAsSwarm<M>> RecipientAsSwarm<ToRandom<M>> for SA {
-    fn receive_packet(swarm: &mut Swarm<SA>, packet: &Packet<ToRandom<M>>) -> Fate {
-        if swarm.slot_map.len() > 0 {
-            let mut new_packet = Packet {
-                recipient_id: None,
-                message: packet.message.message.clone(),
-            };
-            for _i in 0..packet.message.n_recipients {
-                let random_id = ID::new(unsafe { (*super::THE_SYSTEM).short_id::<Swarm<SA>>() },
-                                        swarm.slot_map.random_used() as u32,
-                                        0);
-                new_packet.recipient_id = Some(random_id);
-                swarm.receive_packet(&new_packet);
-            }
-        }
-        Fate::Live
-    }
-}
-
-/// A message for adding a new sub-actor to a `Swarm` given its initial state.
-///
-/// Note: although the handler is implemented in `Swarm`, you need to call
-/// `Swarm::<SubActor>::handle::<Create<SubActor>>();`
-/// to actually register the handler for creating sub-actors like this.
-#[derive(Compact, Clone)]
-pub struct Create<SA: SubActor>(pub SA);
-
-#[doc(hidden)]
-pub trait NotACreateMessage {}
-
-impl NotACreateMessage for .. {}
-
-impl<SA: SubActor> !NotACreateMessage for Create<SA> {}
-impl<SA: SubActor, M: Message> !NotACreateMessage for CreateWith<SA, M> {}
-
-impl<SA: SubActor> RecipientAsSwarm<Create<SA>> for SA {
-    fn receive(swarm: &mut Swarm<SA>, msg: &Create<SA>) -> Fate {
-        match *msg {
-            Create(ref initial_state) => {
-                swarm.add(initial_state);
+impl<'a, SA: SubActor + 'static> SubActorDefiner<'a, SA> {
+    pub fn on_packet<M: Message, F>(&mut self, handler: F, critical: bool)
+        where F: Fn(&Packet<M>, &mut SA, &mut World) -> Fate + 'static
+    {
+        self.0
+            .on_packet(move |packet: &Packet<M>, swarm, world| {
+                if packet
+                       .recipient_id
+                       .expect("Recipient ID not set")
+                       .sub_actor_id == broadcast_sub_actor_id() {
+                    swarm.receive_broadcast(packet, &handler, world);
+                } else {
+                    swarm.receive_instance(packet, &handler, world);
+                }
                 Fate::Live
-            }
-        }
+            },
+                       critical);
+
+
     }
-}
 
-/// A message for adding a new sub-actor to a `Swarm` given its initial state
-/// and an initial message that the sub-actor will handle immediately after creation.
-///
-/// Note: although the handler is implemented in `Swarm`, you need to call
-/// `Swarm::<SubActor>::handle::<CreateWith<SubActor, Message>>();`
-/// to actually register the handler for creating sub-actors like this.
-#[derive(Compact, Clone)]
-pub struct CreateWith<SA: SubActor, M: Message>(pub SA, pub M);
+    pub fn on_maybe_critical<M: Message, F>(&mut self, handler: F, critical: bool)
+        where F: Fn(&M, &mut SA, &mut World) -> Fate + 'static
+    {
+        self.on_packet(move |packet: &Packet<M>, state, world| {
+            handler(&packet.message, state, world)
+        },
+                       critical);
+    }
 
-impl<M: Message, SA: SubActor + Recipient<M>> RecipientAsSwarm<CreateWith<SA, M>> for SA {
-    fn receive(swarm: &mut Swarm<SA>, msg: &CreateWith<SA, M>) -> Fate {
-        match *msg {
-            CreateWith(ref initial_state, ref initial_message) => {
-                let id = swarm.add(initial_state);
-                let initial_packet = Packet {
-                    recipient_id: Some(id),
-                    message: (*initial_message).clone(),
-                };
-                swarm.receive_instance(&initial_packet);
+    pub fn on<M: Message, F>(&mut self, handler: F)
+        where F: Fn(&M, &mut SA, &mut World) -> Fate + 'static
+    {
+        self.on_maybe_critical(handler, false);
+    }
+
+    pub fn on_critical<M: Message, F>(&mut self, handler: F)
+        where F: Fn(&M, &mut SA, &mut World) -> Fate + 'static
+    {
+        self.on_maybe_critical(handler, true);
+    }
+
+    pub fn on_create_with<M: Message, F>(&mut self, handler: F)
+        where F: Fn(&M, &mut SA, &mut World) -> Fate + 'static
+    {
+        self.0
+            .on_packet(move |&Packet { ref message, recipient_id }, swarm, world| {
+                let &CreateWith(ref init_state, ref init_message): &CreateWith<SA,
+                                                                               M> = message;
+                let id = swarm.add(init_state, recipient_id.unwrap());
+                world.send(id, (*init_message).clone());
                 Fate::Live
-            }
-        }
+            },
+                       false);
+
+        // also be able to receive this message normally
+        self.on(handler);
+    }
+
+    pub fn on_random<M: Message, F>(&mut self, handler: F)
+        where F: Fn(&M, &mut SA, &mut World) -> Fate + 'static
+    {
+        self.0
+            .on_packet(move |packet: &Packet<ToRandom<M>>, swarm, world| {
+                if swarm.slot_map.len() > 0 {
+                    for _i in 0..packet.message.n_recipients {
+                        let random_id = ID::new(packet.recipient_id.unwrap().type_id,
+                                                swarm.slot_map.random_used() as u32,
+                                                0);
+                        world.send(random_id, packet.message.message.clone());
+                    }
+                }
+                Fate::Live
+            },
+                       false);
+
+        // also be able to receive this message normally
+        self.on(handler);
+    }
+
+    pub fn world(&mut self) -> World {
+        self.0.world()
     }
 }

--- a/lib/kay_macros/src/lib.rs
+++ b/lib/kay_macros/src/lib.rs
@@ -1,4 +1,4 @@
-//! Automatic `#[derive(SubActor)]` macro for structs which have an `_id: ID` field.
+//! Automatic `#[derive(SubActor)]` macro for structs which have an `_id: Option<ID>` field.
 
 #![recursion_limit="100"]
 

--- a/lib/monet/src/lib.rs
+++ b/lib/monet/src/lib.rs
@@ -1,6 +1,5 @@
 #![feature(plugin, conservative_impl_trait)]
 #![plugin(clippy)]
-#![allow(no_effect, unnecessary_operation)]
 
 extern crate descartes;
 #[macro_use]
@@ -12,8 +11,6 @@ extern crate compact_macros;
 extern crate fnv;
 extern crate lazy_static;
 
-use kay::Actor;
-
 mod geometry;
 mod renderer;
 mod render_context;
@@ -23,23 +20,9 @@ mod thing;
 pub use glium::backend::glutin_backend::GlutinFacade;
 
 pub use geometry::{Batch, Vertex, Instance};
-pub use renderer::{Renderer, SetupInScene, RenderToScene, Control, Submitted, AddBatch,
+pub use renderer::{setup, Renderer, SetupInScene, RenderToScene, Control, Submitted, AddBatch,
                    AddInstance, AddSeveralInstances, Movement, MoveEye, EyeMoved, AddEyeListener,
                    UpdateThing, Project2dTo3d, Projected3d};
 pub use render_context::RenderContext;
 pub use scene::{Eye, Scene};
 pub use thing::Thing;
-
-pub fn setup(renderer: Renderer) {
-    Renderer::register_with_state(renderer);
-    Renderer::handle_critically::<Control>();
-    Renderer::handle_critically::<AddBatch>();
-    Renderer::handle_critically::<AddInstance>();
-    Renderer::handle_critically::<AddSeveralInstances>();
-    Renderer::handle_critically::<MoveEye>();
-    Renderer::handle_critically::<AddEyeListener>();
-    Renderer::handle_critically::<UpdateThing>();
-    Renderer::handle_critically::<Project2dTo3d>();
-
-    Renderer::id() << Control::Setup;
-}

--- a/lib/monet/src/renderer/mod.rs
+++ b/lib/monet/src/renderer/mod.rs
@@ -2,7 +2,7 @@
 pub use descartes::{N, P3, P2, V3, V4, M4, Iso3, Persp3, ToHomogeneous, Norm, Into2d, Into3d,
                     WithUniqueOrthogonal, Inverse, Rotate};
 use compact::CVec;
-use kay::{ID, Recipient, Actor, Fate};
+use kay::{ID, Fate};
 
 use glium::backend::glutin_backend::GlutinFacade;
 
@@ -30,23 +30,10 @@ impl Renderer {
     }
 }
 
-impl Actor for Renderer {}
-
 #[derive(Copy, Clone)]
 pub struct AddEyeListener {
     pub scene_id: usize,
     pub listener: ID,
-}
-
-impl Recipient<AddEyeListener> for Renderer {
-    fn receive(&mut self, msg: &AddEyeListener) -> Fate {
-        match *msg {
-            AddEyeListener { scene_id, listener } => {
-                self.scenes[scene_id].eye_listeners.push(listener);
-                Fate::Live
-            }
-        }
-    }
 }
 
 #[derive(Compact, Clone)]
@@ -54,24 +41,6 @@ pub struct AddBatch {
     pub scene_id: usize,
     pub batch_id: u16,
     pub thing: Thing,
-}
-
-impl Recipient<AddBatch> for Renderer {
-    fn receive(&mut self, msg: &AddBatch) -> Fate {
-        match *msg {
-            AddBatch {
-                scene_id,
-                batch_id,
-                ref thing,
-            } => {
-                let window = &self.render_context.window;
-                self.scenes[scene_id]
-                    .batches
-                    .insert(batch_id, Batch::new(thing.clone(), window));
-                Fate::Live
-            }
-        }
-    }
 }
 
 #[derive(Compact, Clone)]
@@ -83,52 +52,11 @@ pub struct UpdateThing {
     pub is_decal: bool,
 }
 
-impl Recipient<UpdateThing> for Renderer {
-    fn receive(&mut self, msg: &UpdateThing) -> Fate {
-        match *msg {
-            UpdateThing {
-                scene_id,
-                thing_id,
-                ref thing,
-                instance,
-                is_decal,
-            } => {
-                let thing = Batch::new_thing(thing.clone(),
-                                             instance,
-                                             is_decal,
-                                             &self.render_context.window);
-                self.scenes[scene_id].batches.insert(thing_id, thing);
-                Fate::Live
-            }
-        }
-    }
-}
-
 #[derive(Copy, Clone)]
 pub struct AddInstance {
     pub scene_id: usize,
     pub batch_id: u16,
     pub instance: Instance,
-}
-
-impl Recipient<AddInstance> for Renderer {
-    fn receive(&mut self, msg: &AddInstance) -> Fate {
-        match *msg {
-            AddInstance {
-                scene_id,
-                batch_id,
-                instance,
-            } => {
-                self.scenes[scene_id]
-                    .batches
-                    .get_mut(&batch_id)
-                    .unwrap()
-                    .instances
-                    .push(instance);
-                Fate::Live
-            }
-        }
-    }
 }
 
 #[derive(Compact, Clone)]
@@ -138,22 +66,65 @@ pub struct AddSeveralInstances {
     pub instances: CVec<Instance>,
 }
 
-impl Recipient<AddSeveralInstances> for Renderer {
-    fn receive(&mut self, msg: &AddSeveralInstances) -> Fate {
-        match *msg {
-            AddSeveralInstances {
-                scene_id,
-                batch_id,
-                ref instances,
-            } => {
-                self.scenes[scene_id]
-                    .batches
-                    .get_mut(&batch_id)
-                    .unwrap()
-                    .instances
-                    .extend_from_slice(instances);
-                Fate::Live
-            }
-        }
-    }
+use kay::ActorSystem;
+
+pub fn setup(system: &mut ActorSystem, initial: Renderer) {
+    system.add(initial, |mut the_renderer| {
+
+        the_renderer.on_critical(|&AddEyeListener { scene_id, listener }, renderer, _| {
+            renderer.scenes[scene_id].eye_listeners.push(listener);
+            Fate::Live
+        });
+
+        the_renderer.on_critical(|&AddBatch { scene_id, batch_id, ref thing }, renderer, _| {
+            let window = &renderer.render_context.window;
+            renderer.scenes[scene_id]
+                .batches
+                .insert(batch_id, Batch::new(thing.clone(), window));
+            Fate::Live
+        });
+
+        the_renderer.on_critical(|&UpdateThing {
+                                       scene_id,
+                                       thing_id,
+                                       ref thing,
+                                       instance,
+                                       is_decal,
+                                   },
+                                  renderer,
+                                  _| {
+            let thing = Batch::new_thing(thing.clone(),
+                                         instance,
+                                         is_decal,
+                                         &renderer.render_context.window);
+            renderer.scenes[scene_id].batches.insert(thing_id, thing);
+            Fate::Live
+        });
+
+        the_renderer.on_critical(|&AddInstance { scene_id, batch_id, instance }, renderer, _| {
+            renderer.scenes[scene_id]
+                .batches
+                .get_mut(&batch_id)
+                .unwrap()
+                .instances
+                .push(instance);
+            Fate::Live
+        });
+
+        the_renderer.on_critical(|&AddSeveralInstances { scene_id, batch_id, ref instances },
+                                  renderer,
+                                  _| {
+            renderer.scenes[scene_id]
+                .batches
+                .get_mut(&batch_id)
+                .unwrap()
+                .instances
+                .extend_from_slice(instances);
+            Fate::Live
+        });
+
+    });
+    control::setup(system);
+    movement::setup(system);
+    project::setup(system);
 }

--- a/lib/monet/src/renderer/project.rs
+++ b/lib/monet/src/renderer/project.rs
@@ -1,7 +1,7 @@
 
 pub use descartes::{N, P3, P2, V3, V4, M4, Iso3, Persp3, ToHomogeneous, Norm, Into2d, Into3d,
                     WithUniqueOrthogonal, Inverse, Rotate};
-use kay::{ID, Recipient, Fate};
+use kay::{ID, ActorSystem, Fate};
 
 use Renderer;
 
@@ -17,51 +17,53 @@ pub struct Projected3d {
     pub position_3d: P3,
 }
 
-impl Recipient<Project2dTo3d> for Renderer {
-    fn receive(&mut self, msg: &Project2dTo3d) -> Fate {
-        let &Project2dTo3d {
-                 scene_id,
-                 position_2d,
-                 requester,
-             } = msg;
+pub fn setup(system: &mut ActorSystem) {
+    system.extend::<Renderer, _>(|mut the_renderer| {
+        the_renderer.on_critical(|&Project2dTo3d { scene_id, position_2d, requester },
+                                  renderer,
+                                  world| {
+            let eye = &renderer.scenes[scene_id].eye;
+            let frame_size = renderer
+                .render_context
+                .window
+                .get_framebuffer_dimensions();
 
-        let eye = &self.scenes[scene_id].eye;
-        let frame_size = self.render_context.window.get_framebuffer_dimensions();
+            // mouse is on the close plane of the frustum
+            let normalized_2d_position = V4::new((position_2d.x / (frame_size.0 as N)) * 2.0 - 1.0,
+                                                 (-position_2d.y / (frame_size.1 as N)) * 2.0 +
+                                                 1.0,
+                                                 -1.0,
+                                                 1.0);
 
-        // mouse is on the close plane of the frustum
-        let normalized_2d_position = V4::new((position_2d.x / (frame_size.0 as N)) * 2.0 - 1.0,
-                                             (-position_2d.y / (frame_size.1 as N)) * 2.0 + 1.0,
-                                             -1.0,
-                                             1.0);
-
-        let inverse_view = Iso3::look_at_rh(&eye.position, &eye.target, &eye.up)
-            .to_homogeneous()
-            .inverse()
-            .unwrap();
-        let inverse_perspective = Persp3::new(frame_size.0 as f32 / frame_size.1 as f32,
-                                              eye.field_of_view,
-                                              0.1,
-                                              1000.0)
-                .to_matrix()
+            let inverse_view = Iso3::look_at_rh(&eye.position, &eye.target, &eye.up)
+                .to_homogeneous()
                 .inverse()
                 .unwrap();
+            let inverse_perspective = Persp3::new(frame_size.0 as f32 / frame_size.1 as f32,
+                                                  eye.field_of_view,
+                                                  0.1,
+                                                  1000.0)
+                    .to_matrix()
+                    .inverse()
+                    .unwrap();
 
-        // converts from frustum to position relative to camera
-        let mut position_from_camera = inverse_perspective * normalized_2d_position;
-        // reinterpret that as a vector (direction)
-        position_from_camera.w = 0.0;
-        // convert into world coordinates
-        let direction_into_world = inverse_view * position_from_camera;
+            // converts from frustum to position relative to camera
+            let mut position_from_camera = inverse_perspective * normalized_2d_position;
+            // reinterpret that as a vector (direction)
+            position_from_camera.w = 0.0;
+            // convert into world coordinates
+            let direction_into_world = inverse_view * position_from_camera;
 
-        let direction_into_world_3d = V3::new(direction_into_world.x,
-                                              direction_into_world.y,
-                                              direction_into_world.z);
-        // / direction_into_world.w;
+            let direction_into_world_3d = V3::new(direction_into_world.x,
+                                                  direction_into_world.y,
+                                                  direction_into_world.z);
+            // / direction_into_world.w;
 
-        let distance = -eye.position.z / direction_into_world_3d.z;
-        let position_in_world = eye.position + distance * direction_into_world_3d;
+            let distance = -eye.position.z / direction_into_world_3d.z;
+            let position_in_world = eye.position + distance * direction_into_world_3d;
 
-        requester << Projected3d { position_3d: position_in_world };
-        Fate::Live
-    }
+            world.send(requester, Projected3d { position_3d: position_in_world });
+            Fate::Live
+        })
+    });
 }

--- a/lib/stagemaster/src/camera_control.rs
+++ b/lib/stagemaster/src/camera_control.rs
@@ -1,4 +1,4 @@
-use kay::{Actor, Recipient, Fate};
+use kay::{ActorSystem, Fate};
 use monet::{Renderer, MoveEye, Movement};
 use descartes::{P2, P3, V3};
 use combo::Button::*;
@@ -65,167 +65,176 @@ impl CameraControl {
     }
 }
 
-impl Actor for CameraControl {}
-
-use super::Event3d;
-
-impl Recipient<Event3d> for CameraControl {
-    fn receive(&mut self, msg: &Event3d) -> Fate {
-        match *msg {
-            Event3d::Combos(combos) => {
-                self.settings.bindings.do_rebinding(&combos.current);
-                self.forward = self.settings.bindings["Move Forward"].is_in(&combos);
-                self.backward = self.settings.bindings["Move Backward"].is_in(&combos);
-                self.left = self.settings.bindings["Move Left"].is_in(&combos);
-                self.right = self.settings.bindings["Move Right"].is_in(&combos);
-                self.pan_modifier = self.settings.bindings["Pan"].is_in(&combos);
-                self.yaw_modifier = self.settings.bindings["Yaw"].is_in(&combos);
-                self.pitch_modifier = self.settings.bindings["Pitch"].is_in(&combos);
-            }
-            Event3d::MouseMove(cursor_2d) => {
-                let delta = cursor_2d - self.last_cursor_2d;
-                self.last_cursor_2d = cursor_2d;
-
-                if self.yaw_modifier {
-                    Renderer::id() <<
-                    MoveEye {
-                        scene_id: 0,
-                        movement: Movement::Yaw(-delta.x * self.settings.rotation_speed / 300.0),
-                    };
-                }
-
-                if self.pitch_modifier {
-                    Renderer::id() <<
-                    MoveEye {
-                        scene_id: 0,
-                        movement: Movement::Pitch(-delta.y * self.settings.rotation_speed *
-                                                  if self.settings.invert_y { -1.0 } else { 1.0 } /
-                                                  300.0),
-                    };
-                }
-            }
-            Event3d::MouseMove3d(cursor_3d) => {
-                let delta = cursor_3d - self.last_cursor_3d;
-                self.last_cursor_3d = cursor_3d;
-
-                if self.pan_modifier {
-                    Renderer::id() <<
-                    MoveEye {
-                        scene_id: 0,
-                        movement: Movement::ShiftAbsolute(-delta),
-                    };
-                    // predict next movement to avoid jitter
-                    self.last_cursor_3d -= delta;
-                }
-            }
-            Event3d::Scroll(delta) => {
-                Renderer::id() <<
-                MoveEye {
-                    scene_id: 0,
-                    movement: Movement::Zoom(delta.y * self.settings.zoom_speed,
-                                             self.last_cursor_3d),
-                };
-            }
-            Event3d::Frame => {
-                if self.forward {
-                    Renderer::id() <<
-                    MoveEye {
-                        scene_id: 0,
-                        movement: Movement::Shift(V3::new(5.0 * self.settings.move_speed,
-                                                          0.0,
-                                                          0.0)),
-                    };
-                }
-                if self.backward {
-                    Renderer::id() <<
-                    MoveEye {
-                        scene_id: 0,
-                        movement: Movement::Shift(V3::new(-5.0 * self.settings.move_speed,
-                                                          0.0,
-                                                          0.0)),
-                    };
-                }
-                if self.left {
-                    Renderer::id() <<
-                    MoveEye {
-                        scene_id: 0,
-                        movement: Movement::Shift(V3::new(0.0,
-                                                          -5.0 * self.settings.move_speed,
-                                                          0.0)),
-                    };
-                }
-                if self.right {
-                    Renderer::id() <<
-                    MoveEye {
-                        scene_id: 0,
-                        movement: Movement::Shift(V3::new(0.0,
-                                                          5.0 * self.settings.move_speed,
-                                                          0.0)),
-                    };
-                }
-            }
-            _ => {}
-        }
-        Fate::Live
-    }
-}
-
-use super::DrawUI2d;
-use super::Ui2dDrawn;
-use imgui::ImGuiSetCond_FirstUseEver;
-
-impl Recipient<DrawUI2d> for CameraControl {
-    fn receive(&mut self, msg: &DrawUI2d) -> Fate {
-        match *msg {
-            DrawUI2d { ui_ptr, return_to } => {
-                let ui = unsafe { Box::from_raw(ui_ptr as *mut ::imgui::Ui) };
-
-                let mut settings_changed = false;
-
-                ui.window(im_str!("Controls"))
-                    .size((600.0, 200.0), ImGuiSetCond_FirstUseEver)
-                    .collapsible(false)
-                    .build(|| {
-                        ui.text(im_str!("Camera Movement"));
-                        ui.separator();
-
-                        ui.text(im_str!("Move Speed"));
-                        ui.same_line(150.0);
-                        settings_changed =
-                            settings_changed ||
-                            ui.slider_float(im_str!(""), &mut self.settings.move_speed, 0.1, 10.0)
-                                .build();
-
-                        settings_changed = settings_changed ||
-                                           ui.checkbox(im_str!("Invert Y"),
-                                                       &mut self.settings.invert_y);
-
-                        settings_changed = settings_changed ||
-                                           self.settings.bindings.settings_ui(&ui);
-
-                        ui.spacing();
-
-                    });
-
-                if settings_changed {
-                    self.env.write_settings("Camera Control", &self.settings);
-                }
-
-                return_to << Ui2dDrawn { ui_ptr: Box::into_raw(ui) as usize };
-                Fate::Live
-            }
-        }
-    }
-}
-
-pub fn setup(env: &'static Environment) {
+pub fn setup(system: &mut ActorSystem, env: &'static Environment) {
     let settings = env.load_settings("Camera Control");
     let state = CameraControl::new(settings, env);
-    CameraControl::register_with_state(state);
-    CameraControl::handle_critically::<Event3d>();
-    CameraControl::handle_critically::<DrawUI2d>();
-    super::UserInterface::id() <<
-    super::AddInteractable(CameraControl::id(), super::AnyShape::Everywhere, 0);
-    super::UserInterface::id() << super::AddInteractable2d(CameraControl::id());
-    super::UserInterface::id() << super::Focus(CameraControl::id());
+
+    use super::Event3d;
+
+    system.add(state, |mut the_renderer| {
+        let renderer_id = the_renderer.world().id::<Renderer>();
+
+        the_renderer.on_critical(move |event, cc, world| {
+            match *event {
+                Event3d::Combos(combos) => {
+                    cc.settings.bindings.do_rebinding(&combos.current);
+                    cc.forward = cc.settings.bindings["Move Forward"].is_in(&combos);
+                    cc.backward = cc.settings.bindings["Move Backward"].is_in(&combos);
+                    cc.left = cc.settings.bindings["Move Left"].is_in(&combos);
+                    cc.right = cc.settings.bindings["Move Right"].is_in(&combos);
+                    cc.pan_modifier = cc.settings.bindings["Pan"].is_in(&combos);
+                    cc.yaw_modifier = cc.settings.bindings["Yaw"].is_in(&combos);
+                    cc.pitch_modifier = cc.settings.bindings["Pitch"].is_in(&combos);
+                }
+                Event3d::MouseMove(cursor_2d) => {
+                    let delta = cursor_2d - cc.last_cursor_2d;
+                    cc.last_cursor_2d = cursor_2d;
+
+                    if cc.yaw_modifier {
+                        world.send(renderer_id,
+                                   MoveEye {
+                                       scene_id: 0,
+                                       movement: Movement::Yaw(-delta.x *
+                                                               cc.settings.rotation_speed /
+                                                               300.0),
+                                   });
+                    }
+
+                    if cc.pitch_modifier {
+                        world.send(renderer_id,
+                                   MoveEye {
+                                       scene_id: 0,
+                                       movement: Movement::Pitch(-delta.y *
+                                                                 cc.settings.rotation_speed *
+                                                                 if cc.settings.invert_y {
+                                                                     -1.0
+                                                                 } else {
+                                                                     1.0
+                                                                 } /
+                                                                 300.0),
+                                   });
+                    }
+                }
+                Event3d::MouseMove3d(cursor_3d) => {
+                    let delta = cursor_3d - cc.last_cursor_3d;
+                    cc.last_cursor_3d = cursor_3d;
+
+                    if cc.pan_modifier {
+                        world.send(renderer_id,
+                                   MoveEye {
+                                       scene_id: 0,
+                                       movement: Movement::ShiftAbsolute(-delta),
+                                   });
+                        // predict next movement to avoid jitter
+                        cc.last_cursor_3d -= delta;
+                    }
+                }
+                Event3d::Scroll(delta) => {
+                    world.send(renderer_id,
+                               MoveEye {
+                                   scene_id: 0,
+                                   movement: Movement::Zoom(delta.y * cc.settings.zoom_speed,
+                                                            cc.last_cursor_3d),
+                               });
+                }
+                Event3d::Frame => {
+                    if cc.forward {
+                        world.send(renderer_id,
+                                   MoveEye {
+                                       scene_id: 0,
+                                       movement: Movement::Shift(V3::new(5.0 *
+                                                                         cc.settings.move_speed,
+                                                                         0.0,
+                                                                         0.0)),
+                                   });
+                    }
+                    if cc.backward {
+                        world.send(renderer_id,
+                                   MoveEye {
+                                       scene_id: 0,
+                                       movement: Movement::Shift(V3::new(-5.0 *
+                                                                         cc.settings.move_speed,
+                                                                         0.0,
+                                                                         0.0)),
+                                   });
+                    }
+                    if cc.left {
+                        world.send(renderer_id,
+                                   MoveEye {
+                                       scene_id: 0,
+                                       movement: Movement::Shift(V3::new(0.0,
+                                                                         -5.0 *
+                                                                         cc.settings.move_speed,
+                                                                         0.0)),
+                                   });
+                    }
+                    if cc.right {
+                        world.send(renderer_id,
+                                   MoveEye {
+                                       scene_id: 0,
+                                       movement: Movement::Shift(V3::new(0.0,
+                                                                         5.0 *
+                                                                         cc.settings.move_speed,
+                                                                         0.0)),
+                                   });
+                    }
+                }
+                _ => {}
+            }
+            Fate::Live
+        });
+
+
+        use super::DrawUI2d;
+        use super::Ui2dDrawn;
+        use imgui::ImGuiSetCond_FirstUseEver;
+
+        the_renderer.on_critical(|&DrawUI2d { ui_ptr, return_to }, cc, world| {
+            let ui = unsafe { Box::from_raw(ui_ptr as *mut ::imgui::Ui) };
+
+            let mut settings_changed = false;
+
+            ui.window(im_str!("Controls"))
+                .size((600.0, 200.0), ImGuiSetCond_FirstUseEver)
+                .collapsible(false)
+                .build(|| {
+                    ui.text(im_str!("Camera Movement"));
+                    ui.separator();
+
+                    ui.text(im_str!("Move Speed"));
+                    ui.same_line(150.0);
+                    settings_changed =
+                        settings_changed ||
+                        ui.slider_float(im_str!(""), &mut cc.settings.move_speed, 0.1, 10.0)
+                            .build();
+
+                    settings_changed = settings_changed ||
+                                       ui.checkbox(im_str!("Invert Y"), &mut cc.settings.invert_y);
+
+                    settings_changed = settings_changed || cc.settings.bindings.settings_ui(&ui);
+
+                    ui.spacing();
+
+                });
+
+            if settings_changed {
+                cc.env.write_settings("Camera Control", &cc.settings);
+            }
+
+            world.send(return_to, Ui2dDrawn { ui_ptr: Box::into_raw(ui) as usize });
+            Fate::Live
+        });
+
+        let ui_id = the_renderer.world().id::<super::UserInterface>();
+        let cc_id = the_renderer.world().id::<CameraControl>();
+
+        the_renderer
+            .world()
+            .send(ui_id,
+                  super::AddInteractable(cc_id, super::AnyShape::Everywhere, 0));
+        the_renderer
+            .world()
+            .send(ui_id, super::AddInteractable2d(cc_id));
+        the_renderer.world().send(ui_id, super::Focus(cc_id));
+    });
 }

--- a/lib/stagemaster/src/combo.rs
+++ b/lib/stagemaster/src/combo.rs
@@ -53,9 +53,9 @@ impl Combo {
         self.0
             .iter()
             .all(|opt| {
-                     opt.map(|item| other.0.contains(&Some(item)))
-                         .unwrap_or(true)
-                 })
+                opt.map(|item| other.0.contains(&Some(item)))
+                    .unwrap_or(true)
+            })
     }
 
     pub fn is_freshly_in(&self, listener: &ComboListener) -> bool {

--- a/lib/stagemaster/src/environment.rs
+++ b/lib/stagemaster/src/environment.rs
@@ -10,10 +10,7 @@ pub struct Environment {
 
 impl Environment {
     fn setting_dir(&self) -> PathBuf {
-        let app_info = ::app_dirs::AppInfo {
-            name: self.name,
-            author: self.author,
-        };
+        let app_info = ::app_dirs::AppInfo { name: self.name, author: self.author };
         ::app_dirs::app_root(::app_dirs::AppDataType::UserConfig, &app_info)
             .expect("Expected settings dir to exist")
             .join(self.version)
@@ -34,8 +31,8 @@ impl Environment {
                   .as_mut()
                   .map_err(|err| format!("{}", err))
                   .and_then(|file| {
-                                ::serde_json::from_reader(file).map_err(|err| format!("{}", err))
-                            }) {
+            ::serde_json::from_reader(file).map_err(|err| format!("{}", err))
+        }) {
             Ok(settings) => settings,
             Err(err) => {
                 println!("Error loading {} settings: {} from {:?}",
@@ -51,16 +48,18 @@ impl Environment {
         where S: Serialize + Default
     {
         if let Err(err) = OpenOptions::new()
-                  .write(true)
-                  .create(true)
-                  .open(self.setting_path(category))
-            .as_mut()
-            .map_err(|err| format!("{}", err))
-            .and_then(|file| {
-                ::serde_json::to_writer_pretty(file, settings).map_err(|err| format!("{}", err))
-            }) {
+               .write(true)
+               .create(true)
+               .open(self.setting_path(category))
+               .as_mut()
+               .map_err(|err| format!("{}", err))
+               .and_then(|file| {
+            ::serde_json::to_writer_pretty(file, settings).map_err(|err| format!("{}", err))
+        }) {
             println!("Error writing {} settings: {} to {:?}",
-                category, err, self.setting_path(category));
+                     category,
+                     err,
+                     self.setting_path(category));
         } else {
             println!("Write {} settings", category);
         }

--- a/lib/stagemaster/src/geometry.rs
+++ b/lib/stagemaster/src/geometry.rs
@@ -1,4 +1,3 @@
-use kay::Actor;
 use descartes::{Path, Band, Segment, P2, N, FiniteCurve, WithUniqueOrthogonal};
 use compact::{CVec, Compact};
 use monet::{Thing, Vertex, Renderer, UpdateThing, Instance};
@@ -64,10 +63,7 @@ impl Compact for AnyShape {
     unsafe fn decompact(&self) -> AnyShape {
         match *self {
             AnyShape::Band(Band { ref path, width }) => {
-                AnyShape::Band(Band {
-                                   path: path.decompact(),
-                                   width: width,
-                               })
+                AnyShape::Band(Band { path: path.decompact(), width: width })
             }
             AnyShape::Circle(circle) => AnyShape::Circle(circle),
             AnyShape::Everywhere => AnyShape::Everywhere,
@@ -158,30 +154,36 @@ pub fn dash_path<P: Path>(path: &P, dash_length: f32, gap_length: f32) -> Vec<P>
 
 static mut LAST_DEBUG_THING: u16 = 0;
 
-pub fn add_debug_path(path: CPath, color: [f32; 3], z: f32) {
-    Renderer::id() <<
-    UpdateThing {
-        scene_id: 0,
-        thing_id: 12000 + unsafe { LAST_DEBUG_THING },
-        thing: band_to_thing(&Band::new(path, 0.2), z),
-        instance: Instance::with_color(color),
-        is_decal: true,
-    };
+use kay::World;
+
+pub fn add_debug_path(path: CPath, color: [f32; 3], z: f32, world: &mut World) {
+    let renderer_id = world.id::<Renderer>();
+    world.send(renderer_id,
+               UpdateThing {
+                   scene_id: 0,
+                   thing_id: 12000 + unsafe { LAST_DEBUG_THING },
+                   thing: band_to_thing(&Band::new(path, 0.2), z),
+                   instance: Instance::with_color(color),
+                   is_decal: true,
+               });
     unsafe { LAST_DEBUG_THING += 1 }
 }
 
-pub fn add_debug_point(point: P2, color: [f32; 3], z: f32) {
-    Renderer::id() <<
-    UpdateThing {
-        scene_id: 0,
-        thing_id: 12000 + unsafe { LAST_DEBUG_THING },
-        thing: Thing::new(vec![Vertex { position: [point.x + -0.5, point.y + -0.5, z] },
-                               Vertex { position: [point.x + 0.5, point.y + -0.5, z] },
-                               Vertex { position: [point.x + 0.5, point.y + 0.5, z] },
-                               Vertex { position: [point.x + -0.5, point.y + 0.5, z] }],
-                          vec![0, 1, 2, 2, 3, 0]),
-        instance: Instance::with_color(color),
-        is_decal: true,
-    };
+pub fn add_debug_point(point: P2, color: [f32; 3], z: f32, world: &mut World) {
+    let renderer_id = world.id::<Renderer>();
+    world.send(renderer_id,
+               UpdateThing {
+                   scene_id: 0,
+                   thing_id: 12000 + unsafe { LAST_DEBUG_THING },
+                   thing: Thing::new(vec![Vertex {
+                                              position: [point.x + -0.5, point.y + -0.5, z],
+                                          },
+                                          Vertex { position: [point.x + 0.5, point.y + -0.5, z] },
+                                          Vertex { position: [point.x + 0.5, point.y + 0.5, z] },
+                                          Vertex { position: [point.x + -0.5, point.y + 0.5, z] }],
+                                     vec![0, 1, 2, 2, 3, 0]),
+                   instance: Instance::with_color(color),
+                   is_decal: true,
+               });
     unsafe { LAST_DEBUG_THING += 1 }
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+closure_block_indent_threshold = 0
+struct_lit_width = 40

--- a/src/core/grid_accelerator.rs
+++ b/src/core/grid_accelerator.rs
@@ -54,10 +54,10 @@ impl GridAccelerator {
                 coordinates_set
                     .iter()
                     .flat_map(|coordinates| {
-                                  self.cells[coordinates]
-                                      .iter()
-                                      .map(|ref_u64| ref_u64 as usize)
-                              })
+                        self.cells[coordinates]
+                            .iter()
+                            .map(|ref_u64| ref_u64 as usize)
+                    })
             })
             .collect::<FnvHashSet<_>>()
             .into_iter()

--- a/src/game/lanes_and_cars/construction/materialized_reality.rs
+++ b/src/game/lanes_and_cars/construction/materialized_reality.rs
@@ -1,5 +1,5 @@
 use compact::{CDict, CVec};
-use kay::{ID, Recipient, Fate, Actor};
+use kay::{ID, ActorSystem, Fate};
 use super::super::planning::plan::{Plan, PlanResult, PlanDelta, PlanResultDelta, IntersectionRef,
                                    TrimmedStrokeRef, TransferStrokeRef, BuiltStrokes};
 
@@ -17,7 +17,6 @@ pub enum MaterializedReality {
     Ready(MaterializedRealityState),
     WaitingForUnbuild(ID, CVec<ID>, MaterializedRealityState, Plan, PlanResult, PlanResultDelta),
 }
-impl Actor for MaterializedReality {}
 use self::MaterializedReality::{Ready, WaitingForUnbuild};
 
 #[derive(Compact, Clone)]
@@ -32,93 +31,233 @@ pub struct SimulationResult(pub PlanResultDelta);
 #[derive(Compact, Clone)]
 pub struct BuiltStrokesChanged(pub BuiltStrokes);
 
-use super::super::planning::plan::LaneStrokeRef;
+pub fn setup(system: &mut ActorSystem) {
+    system.add(MaterializedReality::default(), |mut the_mr| {
+        let mr_id = the_mr.world().id::<MaterializedReality>();
 
-impl Recipient<Simulate> for MaterializedReality {
-    fn receive(&mut self, msg: &Simulate) -> Fate {
-        match *msg {
-            Simulate {
-                requester,
-                ref delta,
-            } => {
-                let state = match *self {
-                    Ready(ref state) |
-                    WaitingForUnbuild(_, _, ref state, _, _, _) => state,
-                };
-                let (new_plan, _) = state.current_plan.with_delta(delta);
-                let result = new_plan.get_result();
-                let result_delta = result.delta(&state.current_result);
-                requester << SimulationResult(result_delta);
-                Fate::Live
+        use super::super::planning::plan::LaneStrokeRef;
+
+        the_mr.on(|&Simulate { requester, ref delta }, mr, world| {
+            let state = match *mr {
+                Ready(ref state) |
+                WaitingForUnbuild(_, _, ref state, _, _, _) => state,
+            };
+            let (new_plan, _) = state.current_plan.with_delta(delta);
+            let result = new_plan.get_result();
+            let result_delta = result.delta(&state.current_result);
+            world.send(requester, SimulationResult(result_delta));
+            Fate::Live
+        });
+
+        use super::super::construction::Unbuild;
+
+        the_mr.on(move |&Apply { ref delta, requester }, mr, world| {
+            *mr = match *mr {
+                WaitingForUnbuild(..) => panic!("Already applying a plan"),
+                Ready(ref mut state) => {
+                    let (new_plan, _) = state.current_plan.with_delta(delta);
+                    let new_result = new_plan.get_result();
+                    let result_delta = new_result.delta(&state.current_result);
+
+                    let mut ids_to_unbuild = CVec::new();
+
+                    for old_ref in result_delta.intersections.to_destroy.keys() {
+                        for id in state.built_intersection_lanes.remove_iter(*old_ref) {
+                            ids_to_unbuild.push(id);
+                        }
+                    }
+
+                    for old_ref in result_delta.trimmed_strokes.to_destroy.keys() {
+                        let id = state
+                            .built_trimmed_lanes
+                            .remove(*old_ref)
+                            .expect("tried to unbuild a non-existing lane");
+                        ids_to_unbuild.push(id);
+                    }
+
+                    for old_ref in result_delta.transfer_strokes.to_destroy.keys() {
+                        let id = state
+                            .built_transfer_lanes
+                            .remove(*old_ref)
+                            .expect("tried to unbuild a non-existing transfer lane");
+                        ids_to_unbuild.push(id);
+                    }
+
+                    for &id in &ids_to_unbuild {
+                        world.send(id, Unbuild { report_to: mr_id });
+                    }
+
+                    world.send(mr_id, ReportLaneUnbuilt(None));
+                    WaitingForUnbuild(requester,
+                                      ids_to_unbuild,
+                                      state.clone(),
+                                      new_plan,
+                                      new_result,
+                                      result_delta)
+                }
+            };
+            Fate::Live
+        });
+
+        use super::AdvertiseForOverlaps;
+
+        the_mr.on(|&ReportLaneBuilt(id, buildable_ref), mr, world| {
+            match *mr {
+                Ready(ref mut state) => {
+                    match buildable_ref {
+                        BuildableRef::Intersection(index) => {
+                            if let Some(other_intersection_lanes) =
+                                state
+                                    .built_intersection_lanes
+                                    .get(IntersectionRef(index)) {
+                                world.send(id,
+                                           AdvertiseForOverlaps {
+                                               lanes: other_intersection_lanes.clone(),
+                                           });
+                            }
+                            state
+                                .built_intersection_lanes
+                                .push_at(IntersectionRef(index), id);
+                        }
+                        BuildableRef::TrimmedStroke(index) => {
+                            state
+                                .built_trimmed_lanes
+                                .insert(TrimmedStrokeRef(index), id);
+                        }
+                        BuildableRef::TransferStroke(index) => {
+                            state
+                                .built_transfer_lanes
+                                .insert(TransferStrokeRef(index), id);
+                        }
+                    }
+                }
+                WaitingForUnbuild(..) => {
+                    panic!("a waiting materialized reality
+                                shouldn't get build reports")
+                }
             }
-        }
-    }
+            Fate::Live
+        });
+
+        the_mr.on(move |&ReportLaneUnbuilt(maybe_id), mr, world| {
+            let maybe_new_mr = match *mr {
+                WaitingForUnbuild(requester,
+                                  ref mut ids_to_unbuild,
+                                  ref state,
+                                  ref new_plan,
+                                  ref new_result,
+                                  ref result_delta) => {
+                    if let Some(id) = maybe_id {
+                        let pos = ids_to_unbuild
+                            .iter()
+                            .position(|unbuild_id| *unbuild_id == id)
+                            .expect("Trying to delete unexpected id");
+                        ids_to_unbuild.remove(pos);
+                    }
+                    if ids_to_unbuild.is_empty() {
+                        for (&IntersectionRef(new_index), new_intersection) in
+                            result_delta.intersections.to_create.pairs() {
+                            for (stroke, timings) in
+                                new_intersection
+                                    .strokes
+                                    .iter()
+                                    .zip(new_intersection.timings.iter()) {
+                                stroke.build_intersection(mr_id,
+                                                          BuildableRef::Intersection(new_index),
+                                                          timings.clone(),
+                                                          world);
+                            }
+                        }
+
+                        for (&TrimmedStrokeRef(new_index), new_stroke) in
+                            result_delta.trimmed_strokes.to_create.pairs() {
+                            new_stroke.build(mr_id, BuildableRef::TrimmedStroke(new_index), world);
+                        }
+
+                        for (&TransferStrokeRef(new_index), new_stroke) in
+                            result_delta.transfer_strokes.to_create.pairs() {
+                            new_stroke.build_transfer(mr_id,
+                                                      BuildableRef::TransferStroke(new_index),
+                                                      world);
+                        }
+
+                        let new_built_intersection_lanes =
+                            state
+                                .built_intersection_lanes
+                                .pairs()
+                                .map(|(old_ref, ids)| {
+                                    let new_ref = result_delta.intersections
+                                        .old_to_new
+                                        .get(*old_ref)
+                                        .expect("attempted to resurrect a destroyed intersection");
+                                    (*new_ref, ids.clone())
+                                })
+                                .collect();
+
+                        let new_built_trimmed_lanes = state
+                            .built_trimmed_lanes
+                            .pairs()
+                            .map(|(old_ref, id)| {
+                                let new_ref = result_delta
+                                    .trimmed_strokes
+                                    .old_to_new
+                                    .get(*old_ref)
+                                    .expect("attempted to resurrect a destroyed trimmed \
+                                                 stroke");
+                                (*new_ref, *id)
+                            })
+                            .collect();
+
+                        let new_built_transfer_lanes = state
+                            .built_transfer_lanes
+                            .pairs()
+                            .map(|(old_ref, id)| {
+                                let new_ref = result_delta
+                                    .transfer_strokes
+                                    .old_to_new
+                                    .get(*old_ref)
+                                    .expect("attempted to resurrect a destroyed transfer \
+                                                 stroke");
+                                (*new_ref, *id)
+                            })
+                            .collect();
+
+                        let built_strokes = BuiltStrokes {
+                            mapping: new_plan
+                                .strokes
+                                .iter()
+                                .enumerate()
+                                .map(|(idx, stroke)| (LaneStrokeRef(idx), stroke.clone()))
+                                .collect(),
+                        };
+
+                        world.send(requester, BuiltStrokesChanged(built_strokes));
+
+                        Some(Ready(MaterializedRealityState {
+                                       current_plan: new_plan.clone(),
+                                       current_result: new_result.clone(),
+                                       built_intersection_lanes: new_built_intersection_lanes,
+                                       built_trimmed_lanes: new_built_trimmed_lanes,
+                                       built_transfer_lanes: new_built_transfer_lanes,
+                                   }))
+                    } else {
+                        None
+                    }
+                }
+                Ready(_) => panic!("Can't unbuild when materialized reality is in ready state"),
+            };
+            if let Some(new_mr) = maybe_new_mr {
+                *mr = new_mr;
+            }
+            Fate::Live
+        })
+    })
 }
 
 #[derive(Compact, Clone)]
 pub struct Apply {
     pub requester: ID,
     pub delta: PlanDelta,
-}
-
-use super::super::construction::Unbuild;
-
-impl Recipient<Apply> for MaterializedReality {
-    #[inline(never)]
-    fn receive(&mut self, msg: &Apply) -> Fate {
-        match *msg {
-            Apply {
-                ref delta,
-                requester,
-            } => {
-                *self = match *self {
-                    WaitingForUnbuild(..) => panic!("Already applying a plan"),
-                    Ready(ref mut state) => {
-                        let (new_plan, _) = state.current_plan.with_delta(delta);
-                        let new_result = new_plan.get_result();
-                        let result_delta = new_result.delta(&state.current_result);
-
-                        let mut ids_to_unbuild = CVec::new();
-
-                        for old_ref in result_delta.intersections.to_destroy.keys() {
-                            for id in state.built_intersection_lanes.remove_iter(*old_ref) {
-                                ids_to_unbuild.push(id);
-                            }
-                        }
-
-                        for old_ref in result_delta.trimmed_strokes.to_destroy.keys() {
-                            let id = state
-                                .built_trimmed_lanes
-                                .remove(*old_ref)
-                                .expect("tried to unbuild a non-existing lane");
-                            ids_to_unbuild.push(id);
-                        }
-
-                        for old_ref in result_delta.transfer_strokes.to_destroy.keys() {
-                            let id = state
-                                .built_transfer_lanes
-                                .remove(*old_ref)
-                                .expect("tried to unbuild a non-existing transfer lane");
-                            ids_to_unbuild.push(id);
-                        }
-
-                        for &id in &ids_to_unbuild {
-                            id << Unbuild { report_to: Self::id() };
-                        }
-
-                        Self::id() << ReportLaneUnbuilt(None);
-                        WaitingForUnbuild(requester,
-                                          ids_to_unbuild,
-                                          state.clone(),
-                                          new_plan,
-                                          new_result,
-                                          result_delta)
-                    }
-                };
-                Fate::Live
-            }
-        }
-    }
 }
 
 #[derive(Copy, Clone, PartialEq, Eq)]
@@ -130,172 +269,9 @@ pub enum BuildableRef {
 
 #[derive(Copy, Clone)]
 pub struct ReportLaneBuilt(pub ID, pub BuildableRef);
-use super::AdvertiseForOverlaps;
-
-impl Recipient<ReportLaneBuilt> for MaterializedReality {
-    fn receive(&mut self, msg: &ReportLaneBuilt) -> Fate {
-        match *msg {
-            ReportLaneBuilt(id, buildable_ref) => {
-                match *self {
-                    Ready(ref mut state) => {
-                        match buildable_ref {
-                            BuildableRef::Intersection(index) => {
-                                if let Some(other_intersection_lanes) =
-                                    state
-                                        .built_intersection_lanes
-                                        .get(IntersectionRef(index)) {
-                                    id <<
-                                    AdvertiseForOverlaps {
-                                        lanes: other_intersection_lanes.clone(),
-                                    };
-                                }
-                                state
-                                    .built_intersection_lanes
-                                    .push_at(IntersectionRef(index), id);
-                            }
-                            BuildableRef::TrimmedStroke(index) => {
-                                state
-                                    .built_trimmed_lanes
-                                    .insert(TrimmedStrokeRef(index), id);
-                            }
-                            BuildableRef::TransferStroke(index) => {
-                                state
-                                    .built_transfer_lanes
-                                    .insert(TransferStrokeRef(index), id);
-                            }
-                        }
-                    }
-                    WaitingForUnbuild(..) => {
-                        panic!("a waiting materialized reality
-                                shouldn't get build reports")
-                    }
-                }
-                Fate::Live
-            }
-        }
-    }
-}
 
 #[derive(Copy, Clone)]
 pub struct ReportLaneUnbuilt(pub Option<ID>);
-
-impl Recipient<ReportLaneUnbuilt> for MaterializedReality {
-    fn receive(&mut self, msg: &ReportLaneUnbuilt) -> Fate {
-        match *msg {
-            ReportLaneUnbuilt(maybe_id) => {
-                let maybe_new_self = match *self {
-                    WaitingForUnbuild(requester,
-                                      ref mut ids_to_unbuild,
-                                      ref state,
-                                      ref new_plan,
-                                      ref new_result,
-                                      ref result_delta) => {
-                        if let Some(id) = maybe_id {
-                            let pos = ids_to_unbuild
-                                .iter()
-                                .position(|unbuild_id| *unbuild_id == id)
-                                .expect("Trying to delete unexpected id");
-                            ids_to_unbuild.remove(pos);
-                        }
-                        if ids_to_unbuild.is_empty() {
-                            for (&IntersectionRef(new_index), new_intersection) in
-                                result_delta.intersections.to_create.pairs() {
-                                for (stroke, timings) in
-                                    new_intersection
-                                        .strokes
-                                        .iter()
-                                        .zip(new_intersection.timings.iter()) {
-                                    stroke
-                                        .build_intersection(MaterializedReality::id(),
-                                                            BuildableRef::Intersection(new_index),
-                                                            timings.clone());
-                                }
-                            }
-
-                            for (&TrimmedStrokeRef(new_index), new_stroke) in
-                                result_delta.trimmed_strokes.to_create.pairs() {
-                                new_stroke.build(MaterializedReality::id(),
-                                                 BuildableRef::TrimmedStroke(new_index));
-                            }
-
-                            for (&TransferStrokeRef(new_index), new_stroke) in
-                                result_delta.transfer_strokes.to_create.pairs() {
-                                new_stroke.build_transfer(MaterializedReality::id(),
-                                                          BuildableRef::TransferStroke(new_index));
-                            }
-
-                            let new_built_intersection_lanes = state
-                                .built_intersection_lanes
-                                .pairs()
-                                .map(|(old_ref, ids)| {
-                                         let new_ref = result_delta.intersections
-                                        .old_to_new
-                                        .get(*old_ref)
-                                        .expect("attempted to resurrect a destroyed intersection");
-                                         (*new_ref, ids.clone())
-                                     })
-                                .collect();
-
-                            let new_built_trimmed_lanes = state
-                                .built_trimmed_lanes
-                                .pairs()
-                                .map(|(old_ref, id)| {
-                                    let new_ref = result_delta
-                                        .trimmed_strokes
-                                        .old_to_new
-                                        .get(*old_ref)
-                                        .expect("attempted to resurrect a destroyed trimmed \
-                                                 stroke");
-                                    (*new_ref, *id)
-                                })
-                                .collect();
-
-                            let new_built_transfer_lanes = state
-                                .built_transfer_lanes
-                                .pairs()
-                                .map(|(old_ref, id)| {
-                                    let new_ref = result_delta
-                                        .transfer_strokes
-                                        .old_to_new
-                                        .get(*old_ref)
-                                        .expect("attempted to resurrect a destroyed transfer \
-                                                 stroke");
-                                    (*new_ref, *id)
-                                })
-                                .collect();
-
-                            let built_strokes = BuiltStrokes {
-                                mapping: new_plan
-                                    .strokes
-                                    .iter()
-                                    .enumerate()
-                                    .map(|(idx, stroke)| (LaneStrokeRef(idx), stroke.clone()))
-                                    .collect(),
-                            };
-
-                            requester << BuiltStrokesChanged(built_strokes);
-
-                            Some(Ready(MaterializedRealityState {
-                                           current_plan: new_plan.clone(),
-                                           current_result: new_result.clone(),
-                                           built_intersection_lanes: new_built_intersection_lanes,
-                                           built_trimmed_lanes: new_built_trimmed_lanes,
-                                           built_transfer_lanes: new_built_transfer_lanes,
-                                       }))
-                        } else {
-                            None
-                        }
-                    }
-                    Ready(_) => panic!("Can't unbuild when materialized reality is in ready state"),
-                };
-                if let Some(new_self) = maybe_new_self {
-                    *self = new_self;
-                }
-                Fate::Live
-            }
-        }
-    }
-}
 
 impl Default for MaterializedReality {
     fn default() -> Self {
@@ -307,12 +283,4 @@ impl Default for MaterializedReality {
                   built_transfer_lanes: CDict::new(),
               })
     }
-}
-
-pub fn setup() {
-    MaterializedReality::register_default();
-    MaterializedReality::handle::<Simulate>();
-    MaterializedReality::handle::<Apply>();
-    MaterializedReality::handle::<ReportLaneBuilt>();
-    MaterializedReality::handle::<ReportLaneUnbuilt>();
 }

--- a/src/game/lanes_and_cars/construction/mod.rs
+++ b/src/game/lanes_and_cars/construction/mod.rs
@@ -1,6 +1,6 @@
 use compact::CVec;
-use kay::{ID, Actor, Recipient, Fate};
-use kay::swarm::{Swarm, SubActor, CreateWith};
+use kay::{ID, ActorSystem, Fate};
+use kay::swarm::{Swarm, SubActor};
 use descartes::{N, P2, Dot, Band, Curve, FiniteCurve, Path, RoughlyComparable, Intersect,
                 WithUniqueOrthogonal};
 use itertools::Itertools;
@@ -37,68 +37,450 @@ impl ConstructionInfo {
 #[derive(Copy, Clone)]
 pub struct AdvertiseToTransferAndReport(pub ID, pub BuildableRef);
 
-use self::materialized_reality::ReportLaneBuilt;
+pub fn setup(system: &mut ActorSystem) {
+    let all_lanes_id = system.id::<Swarm<Lane>>().broadcast();
+    let all_transfer_lanes_id = system.id::<Swarm<TransferLane>>().broadcast();
 
-impl Recipient<AdvertiseToTransferAndReport> for Lane {
-    fn receive(&mut self, msg: &AdvertiseToTransferAndReport) -> Fate {
-        match *msg {
-            AdvertiseToTransferAndReport(report_to, report_as) => {
-                Swarm::<Lane>::all() <<
-                Connect {
-                    other_id: self.id(),
-                    other_start: self.construction.path.start(),
-                    other_end: self.construction.path.end(),
-                    other_length: self.construction.path.length(),
-                    reply_needed: true,
-                };
-                Swarm::<TransferLane>::all() <<
-                ConnectTransferToNormal {
-                    other_id: self.id(),
-                    other_path: self.construction.path.clone(),
-                };
-                report_to << ReportLaneBuilt(self.id(), report_as);
-                super::rendering::on_build(self);
-                super::pathfinding::on_build(self);
+    use self::materialized_reality::ReportLaneBuilt;
+
+    system.extend(Swarm::<Lane>::subactors(move |mut each_lane| {
+
+        each_lane.on_create_with(move |&AdvertiseToTransferAndReport(report_to, report_as),
+                                       lane,
+                                       world| {
+            world.send(all_lanes_id,
+                       Connect {
+                           other_id: lane.id(),
+                           other_start: lane.construction.path.start(),
+                           other_end: lane.construction.path.end(),
+                           other_length: lane.construction.path.length(),
+                           reply_needed: true,
+                       });
+            world.send(all_transfer_lanes_id,
+                       ConnectTransferToNormal {
+                           other_id: lane.id(),
+                           other_path: lane.construction.path.clone(),
+                       });
+            world.send(report_to, ReportLaneBuilt(lane.id(), report_as));
+            super::rendering::on_build(lane, world);
+            super::pathfinding::on_build(lane, world);
+            Fate::Live
+        });
+
+        each_lane.on(|&AdvertiseForOverlaps { ref lanes }, lane, world| {
+            for &lane_id in lanes.iter() {
+                world.send(lane_id,
+                           ConnectOverlaps {
+                               other_id: lane.id(),
+                               other_path: lane.construction.path.clone(),
+                               reply_needed: true,
+                           });
+            }
+            Fate::Live
+        });
+
+        each_lane.on(|&Connect {
+                           other_id,
+                           other_start,
+                           other_end,
+                           other_length,
+                           reply_needed,
+                       },
+                      lane,
+                      world| {
+            if other_id == lane.id() {
+                return Fate::Live;
+            };
+
+            let mut connected = false;
+
+            if other_start.is_roughly_within(lane.construction.path.end(), CONNECTION_TOLERANCE) {
+                connected = true;
+
+                if !lane.connectivity
+                        .interactions
+                        .iter()
+                        .any(|interaction| match *interaction {
+                                 Interaction {
+                                     partner_lane,
+                                     kind: InteractionKind::Next { .. },
+                                     ..
+                                 } => partner_lane == other_id,
+                                 _ => false,
+                             }) {
+                    lane.connectivity
+                        .interactions
+                        .push(Interaction {
+                                  partner_lane: other_id,
+                                  start: lane.construction.length,
+                                  partner_start: 0.0,
+                                  kind: InteractionKind::Next { green: false },
+                              });
+                }
+
+                super::pathfinding::on_connect(lane);
+            }
+
+            if other_end.is_roughly_within(lane.construction.path.start(), CONNECTION_TOLERANCE) {
+                connected = true;
+
+                if !lane.connectivity
+                        .interactions
+                        .iter()
+                        .any(|interaction| match *interaction {
+                                 Interaction {
+                                     partner_lane,
+                                     kind: InteractionKind::Previous { .. },
+                                     ..
+                                 } => partner_lane == other_id,
+                                 _ => false,
+                             }) {
+                    lane.connectivity
+                        .interactions
+                        .push(Interaction {
+                                  partner_lane: other_id,
+                                  start: 0.0,
+                                  partner_start: other_length,
+                                  kind: InteractionKind::Previous,
+                              });
+                }
+
+                super::pathfinding::on_connect(lane);
+            }
+
+            if reply_needed && connected {
+                world.send(other_id,
+                           Connect {
+                               other_id: lane.id(),
+                               other_start: lane.construction.path.start(),
+                               other_end: lane.construction.path.end(),
+                               other_length: lane.construction.path.length(),
+                               reply_needed: false,
+                           });
+            }
+
+            Fate::Live
+        });
+
+        each_lane.on(|&ConnectOverlaps { other_id, ref other_path, reply_needed }, lane, world| {
+            MEMOIZED_BANDS_OUTLINES.with(|memoized_bands_outlines_cell| {
+                let memoized_bands_outlines = unsafe { &mut *memoized_bands_outlines_cell.get() };
+                let &(ref lane_band, ref lane_outline) = memoized_bands_outlines
+                    .entry(lane.id())
+                    .or_insert_with(|| {
+                        let band = Band::new(lane.construction.path.clone(), 4.5);
+                        let outline = band.outline();
+                        (band, outline)
+                    }) as
+                                                         &(Band<CPath>, CPath);
+
+                let memoized_bands_outlines = unsafe { &mut *memoized_bands_outlines_cell.get() };
+                let &(ref other_band, ref other_outline) = memoized_bands_outlines
+                    .entry(other_id)
+                    .or_insert_with(|| {
+                        let band = Band::new(other_path.clone(), 4.5);
+                        let outline = band.outline();
+                        (band, outline)
+                    }) as
+                                                           &(Band<CPath>, CPath);
+
+                let intersections = (lane_outline, other_outline).intersect();
+                if intersections.len() >= 2 {
+                    if let ::itertools::MinMaxResult::MinMax((entry_intersection,
+                                                              entry_distance),
+                                                             (exit_intersection, exit_distance)) =
+                        intersections
+                            .iter()
+                            .map(|intersection| {
+                                (intersection,
+                                 lane_band.outline_distance_to_path_distance(intersection.along_a))
+                            })
+                            .minmax_by_key(|&(_, distance)| OrderedFloat(distance)) {
+                        let other_entry_distance =
+                            other_band
+                                .outline_distance_to_path_distance(entry_intersection.along_b);
+                        let other_exit_distance =
+                            other_band.outline_distance_to_path_distance(exit_intersection.along_b);
+
+                        let overlap_kind = if
+                            other_path
+                                .direction_along(other_entry_distance)
+                                .is_roughly_within(lane.construction
+                                                       .path
+                                                       .direction_along(entry_distance),
+                                                   0.1) ||
+                            other_path
+                                .direction_along(other_exit_distance)
+                                .is_roughly_within(lane.construction
+                                                       .path
+                                                       .direction_along(exit_distance),
+                                                   0.1) {
+                            // ::stagemaster::geometry::CPath::add_debug_path(
+                            //     lane.construction.path
+                            //         .subsection(entry_distance, exit_distance).unwrap(),
+                            //     [1.0, 0.5, 0.0],
+                            //     0.3
+                            // );
+                            OverlapKind::Parallel
+                        } else {
+                            // ::stagemaster::geometry::CPath::add_debug_path(
+                            //     lane.construction.path
+                            //         .subsection(entry_distance, exit_distance).unwrap(),
+                            //     [1.0, 0.0, 0.0],
+                            //     0.3
+                            // );
+                            OverlapKind::Conflicting
+                        };
+
+                        lane.connectivity
+                            .interactions
+                            .push(Interaction {
+                                      partner_lane: other_id,
+                                      start: entry_distance,
+                                      partner_start: other_entry_distance.min(other_exit_distance),
+                                      kind: InteractionKind::Overlap {
+                                          end: exit_distance,
+                                          partner_end: other_exit_distance
+                                              .max(other_entry_distance),
+                                          kind: overlap_kind,
+                                      },
+                                  });
+                    } else {
+                        panic!("both entry and exit should exist")
+                    }
+                }
+
+
+                if reply_needed {
+                    world.send(other_id,
+                               ConnectOverlaps {
+                                   other_id: lane.id(),
+                                   other_path: lane.construction.path.clone(),
+                                   reply_needed: false,
+                               });
+                }
+                Fate::Live
+            })
+        });
+
+        each_lane.on(|&ConnectToTransfer { other_id }, lane, world| {
+            world.send(other_id,
+                       ConnectTransferToNormal {
+                           other_id: lane.id(),
+                           other_path: lane.construction.path.clone(),
+                       });
+            Fate::Live
+        });
+
+        each_lane.on(|&AddTransferLaneInteraction(interaction), lane, _| {
+            if !lane.connectivity
+                    .interactions
+                    .iter()
+                    .any(|existing| existing.partner_lane == interaction.partner_lane) {
+                lane.connectivity.interactions.push(interaction);
+                super::pathfinding::on_connect(lane);
+            }
+            Fate::Live
+        });
+
+        each_lane.on(|&Disconnect { other_id }, lane, world| {
+            let interaction_indices_to_remove = lane.connectivity
+                .interactions
+                .iter()
+                .enumerate()
+                .filter_map(|(i, interaction)| if interaction.partner_lane == other_id {
+                                Some(i)
+                            } else {
+                                None
+                            })
+                .collect::<Vec<_>>();
+            // TODO: Cancel trip
+            lane.microtraffic
+                .cars
+                .retain(|car| {
+                    !interaction_indices_to_remove.contains(&(car.next_hop_interaction as usize))
+                });
+            lane.microtraffic
+                .obstacles
+                .retain(|&(_obstacle, from_id)| from_id != other_id);
+            for idx in interaction_indices_to_remove.into_iter().rev() {
+                lane.connectivity.interactions.remove(idx);
+            }
+            super::pathfinding::on_disconnect(lane, other_id);
+            world.send(other_id, ConfirmDisconnect);
+            Fate::Live
+        });
+
+        each_lane.on(|&Unbuild { report_to }, lane, world| {
+            let mut disconnects_remaining = 0;
+            for id in lane.connectivity
+                    .interactions
+                    .iter()
+                    .map(|interaction| interaction.partner_lane)
+                    .unique() {
+                world.send(id, Disconnect { other_id: lane.id() });
+                disconnects_remaining += 1;
+            }
+            super::rendering::on_unbuild(lane, world);
+            MEMOIZED_BANDS_OUTLINES.with(|memoized_bands_outlines_cell| {
+                let memoized_bands_outlines = unsafe { &mut *memoized_bands_outlines_cell.get() };
+                memoized_bands_outlines.remove(&lane.id())
+            });
+            if disconnects_remaining == 0 {
+                world.send(report_to, ReportLaneUnbuilt(Some(lane.id())));
+                Fate::Die
+            } else {
+                lane.construction.disconnects_remaining = disconnects_remaining;
+                lane.construction.unbuilding_for = Some(report_to);
                 Fate::Live
             }
-        }
-    }
-}
+        });
 
-impl Recipient<AdvertiseToTransferAndReport> for TransferLane {
-    fn receive(&mut self, msg: &AdvertiseToTransferAndReport) -> Fate {
-        match *msg {
-            AdvertiseToTransferAndReport(report_to, report_as) => {
-                Swarm::<Lane>::all() << ConnectToTransfer { other_id: self.id() };
-                report_to << ReportLaneBuilt(self.id(), report_as);
-                super::rendering::on_build_transfer(self);
+        each_lane.on(|_: &ConfirmDisconnect, lane, world| {
+            lane.construction.disconnects_remaining -= 1;
+            if lane.construction.disconnects_remaining == 0 {
+                world.send(lane.construction
+                               .unbuilding_for
+                               .expect("should be unbuilding"),
+                           ReportLaneUnbuilt(Some(lane.id())));
+                Fate::Die
+            } else {
                 Fate::Live
             }
-        }
-    }
+        });
+    }));
+
+    system.extend(Swarm::<TransferLane>::subactors(move |mut each_t_lane| {
+
+        each_t_lane.on_create_with(move |&AdvertiseToTransferAndReport(report_to, report_as),
+                                         lane,
+                                         world| {
+            world.send(all_lanes_id, ConnectToTransfer { other_id: lane.id() });
+            world.send(report_to, ReportLaneBuilt(lane.id(), report_as));
+            super::rendering::on_build_transfer(lane, world);
+            Fate::Live
+        });
+
+        each_t_lane.on(|&ConnectTransferToNormal { other_id, ref other_path }, lane, world| {
+            let projections = (other_path.project(lane.construction.path.start()),
+                               other_path.project(lane.construction.path.end()));
+            if let (Some(lane_start_on_other_distance), Some(lane_end_on_other_distance)) =
+                projections {
+                if lane_start_on_other_distance < lane_end_on_other_distance &&
+                   lane_end_on_other_distance - lane_start_on_other_distance > 6.0 {
+                    let lane_start_on_other = other_path.along(lane_start_on_other_distance);
+                    let lane_end_on_other = other_path.along(lane_end_on_other_distance);
+
+                    if lane_start_on_other.is_roughly_within(lane.construction.path.start(), 3.0) &&
+                       lane_end_on_other.is_roughly_within(lane.construction.path.end(), 3.0) {
+                        world.send(other_id,AddTransferLaneInteraction(Interaction {
+                                                       partner_lane: lane.id(),
+                                                       start: lane_start_on_other_distance,
+                                                       partner_start: 0.0,
+                                                       kind: InteractionKind::Overlap {
+                                                           end: lane_start_on_other_distance +
+                                                                lane.construction.length,
+                                                           partner_end: lane.construction.length,
+                                                           kind: OverlapKind::Transfer,
+                                                       },
+                                                   }));
+
+                        let mut distance_covered = 0.0;
+                        let distance_map = lane.construction
+                            .path
+                            .segments()
+                            .iter()
+                            .map(|segment| {
+                                distance_covered += segment.length();
+                                let segment_end_on_other_distance =
+                                    other_path
+                                        .project(segment.end())
+                                        .expect("should contain transfer lane segment end");
+                                (distance_covered,
+                                 segment_end_on_other_distance - lane_start_on_other_distance)
+                            })
+                            .collect();
+
+                        let other_is_right =
+                            (lane_start_on_other - lane.construction.path.start())
+                                .dot(&lane.construction.path.start_direction().orthogonal()) >
+                            0.0;
+
+                        if other_is_right {
+                            lane.connectivity.right = Some((other_id,
+                                                            lane_start_on_other_distance));
+                            lane.connectivity.right_distance_map = distance_map;
+                        } else {
+                            lane.connectivity.left = Some((other_id, lane_start_on_other_distance));
+                            lane.connectivity.left_distance_map = distance_map;
+                        }
+                    }
+                }
+            }
+            Fate::Live
+        });
+
+        each_t_lane.on(|&Disconnect { other_id }, lane, world| {
+            lane.connectivity.left = lane.connectivity
+                .left
+                .and_then(|(left_id, left_start)| if left_id == other_id {
+                              None
+                          } else {
+                              Some((left_id, left_start))
+                          });
+            lane.connectivity.right = lane.connectivity
+                .right
+                .and_then(|(right_id, right_start)| if right_id == other_id {
+                              None
+                          } else {
+                              Some((right_id, right_start))
+                          });
+            world.send(other_id, ConfirmDisconnect);
+            Fate::Live
+        });
+
+        each_t_lane.on(|&Unbuild { report_to }, lane, world| {
+            if let Some((left_id, _)) = lane.connectivity.left {
+                world.send(left_id, Disconnect { other_id: lane.id() });
+            }
+            if let Some((right_id, _)) = lane.connectivity.right {
+                world.send(right_id, Disconnect { other_id: lane.id() });
+            }
+            super::rendering::on_unbuild_transfer(lane, world);
+            if lane.connectivity.left.is_none() && lane.connectivity.right.is_none() {
+                world.send(report_to, ReportLaneUnbuilt(Some(lane.id())));
+                Fate::Die
+            } else {
+                lane.construction.disconnects_remaining = lane.connectivity
+                    .left
+                    .into_iter()
+                    .chain(lane.connectivity.right)
+                    .count() as u8;
+                lane.construction.unbuilding_for = Some(report_to);
+                Fate::Live
+            }
+        });
+
+        each_t_lane.on(|_: &ConfirmDisconnect, lane, world| {
+            lane.construction.disconnects_remaining -= 1;
+            if lane.construction.disconnects_remaining == 0 {
+                world.send(lane.construction
+                               .unbuilding_for
+                               .expect("should be unbuilding"),
+                           ReportLaneUnbuilt(Some(lane.id())));
+                Fate::Die
+            } else {
+                Fate::Live
+            }
+        })
+    }));
+
+    self::materialized_reality::setup(system);
 }
 
 #[derive(Compact, Clone)]
 pub struct AdvertiseForOverlaps {
     lanes: CVec<ID>,
-}
-
-impl Recipient<AdvertiseForOverlaps> for Lane {
-    fn receive(&mut self, msg: &AdvertiseForOverlaps) -> Fate {
-        match *msg {
-            AdvertiseForOverlaps { ref lanes } => {
-                for &lane in lanes.iter() {
-                    lane <<
-                    ConnectOverlaps {
-                        other_id: self.id(),
-                        other_path: self.construction.path.clone(),
-                        reply_needed: true,
-                    };
-                }
-                Fate::Live
-            }
-        }
-    }
 }
 
 const CONNECTION_TOLERANCE: f32 = 0.1;
@@ -110,96 +492,6 @@ pub struct Connect {
     other_end: P2,
     other_length: N,
     reply_needed: bool,
-}
-
-impl Recipient<Connect> for Lane {
-    #[inline(never)]
-    fn receive(&mut self, msg: &Connect) -> Fate {
-        match *msg {
-            Connect {
-                other_id,
-                other_start,
-                other_end,
-                other_length,
-                reply_needed,
-            } => {
-                if other_id == self.id() {
-                    return Fate::Live;
-                };
-
-                let mut connected = false;
-
-                if other_start.is_roughly_within(self.construction.path.end(),
-                                                 CONNECTION_TOLERANCE) {
-                    connected = true;
-
-                    if !self.connectivity
-                            .interactions
-                            .iter()
-                            .any(|interaction| match *interaction {
-                                     Interaction {
-                                         partner_lane,
-                                         kind: InteractionKind::Next { .. },
-                                         ..
-                                     } => partner_lane == other_id,
-                                     _ => false,
-                                 }) {
-                        self.connectivity
-                            .interactions
-                            .push(Interaction {
-                                      partner_lane: other_id,
-                                      start: self.construction.length,
-                                      partner_start: 0.0,
-                                      kind: InteractionKind::Next { green: false },
-                                  });
-                    }
-
-                    super::pathfinding::on_connect(self);
-                }
-
-                if other_end.is_roughly_within(self.construction.path.start(),
-                                               CONNECTION_TOLERANCE) {
-                    connected = true;
-
-                    if !self.connectivity
-                            .interactions
-                            .iter()
-                            .any(|interaction| match *interaction {
-                                     Interaction {
-                                         partner_lane,
-                                         kind: InteractionKind::Previous { .. },
-                                         ..
-                                     } => partner_lane == other_id,
-                                     _ => false,
-                                 }) {
-                        self.connectivity
-                            .interactions
-                            .push(Interaction {
-                                      partner_lane: other_id,
-                                      start: 0.0,
-                                      partner_start: other_length,
-                                      kind: InteractionKind::Previous,
-                                  });
-                    }
-
-                    super::pathfinding::on_connect(self);
-                }
-
-                if reply_needed && connected {
-                    other_id <<
-                    Connect {
-                        other_id: self.id(),
-                        other_start: self.construction.path.start(),
-                        other_end: self.construction.path.end(),
-                        other_length: self.construction.path.length(),
-                        reply_needed: false,
-                    };
-                }
-
-                Fate::Live
-            }
-        }
-    }
 }
 
 use fnv::FnvHashMap;
@@ -217,141 +509,9 @@ pub struct ConnectOverlaps {
     reply_needed: bool,
 }
 
-impl Recipient<ConnectOverlaps> for Lane {
-    fn receive(&mut self, msg: &ConnectOverlaps) -> Fate {
-        match *msg {
-            ConnectOverlaps {
-                other_id,
-                ref other_path,
-                reply_needed,
-            } => {
-                MEMOIZED_BANDS_OUTLINES.with(|memoized_bands_outlines_cell| {
-                    let memoized_bands_outlines =
-                        unsafe { &mut *memoized_bands_outlines_cell.get() };
-                    let &(ref self_band, ref self_outline) = memoized_bands_outlines
-                        .entry(self.id())
-                        .or_insert_with(|| {
-                                            let band = Band::new(self.construction.path.clone(),
-                                                                 4.5);
-                                            let outline = band.outline();
-                                            (band, outline)
-                                        }) as
-                                                             &(Band<CPath>, CPath);
-
-                    let memoized_bands_outlines =
-                        unsafe { &mut *memoized_bands_outlines_cell.get() };
-                    let &(ref other_band, ref other_outline) = memoized_bands_outlines
-                        .entry(other_id)
-                        .or_insert_with(|| {
-                                            let band = Band::new(other_path.clone(), 4.5);
-                                            let outline = band.outline();
-                                            (band, outline)
-                                        }) as
-                                                               &(Band<CPath>, CPath);
-
-                    let intersections = (self_outline, other_outline).intersect();
-                    if intersections.len() >= 2 {
-                        if let ::itertools::MinMaxResult::MinMax((entry_intersection,
-                                                                  entry_distance),
-                                                                 (exit_intersection,
-                                                                  exit_distance)) =
-                            intersections
-                                .iter()
-                                .map(|intersection| {
-                                         (intersection, self_band
-                                        .outline_distance_to_path_distance(intersection.along_a))
-                                     })
-                                .minmax_by_key(|&(_, distance)| OrderedFloat(distance)) {
-                            let other_entry_distance =
-                                other_band
-                                    .outline_distance_to_path_distance(entry_intersection.along_b);
-                            let other_exit_distance =
-                                other_band
-                                    .outline_distance_to_path_distance(exit_intersection.along_b);
-
-                            let overlap_kind = if
-                                other_path
-                                    .direction_along(other_entry_distance)
-                                    .is_roughly_within(self.construction
-                                                           .path
-                                                           .direction_along(entry_distance),
-                                                       0.1) ||
-                                other_path
-                                    .direction_along(other_exit_distance)
-                                    .is_roughly_within(self.construction
-                                                           .path
-                                                           .direction_along(exit_distance),
-                                                       0.1) {
-                                // ::stagemaster::geometry::CPath::add_debug_path(
-                                //     self.construction.path
-                                //         .subsection(entry_distance, exit_distance).unwrap(),
-                                //     [1.0, 0.5, 0.0],
-                                //     0.3
-                                // );
-                                OverlapKind::Parallel
-                            } else {
-                                // ::stagemaster::geometry::CPath::add_debug_path(
-                                //     self.construction.path
-                                //         .subsection(entry_distance, exit_distance).unwrap(),
-                                //     [1.0, 0.0, 0.0],
-                                //     0.3
-                                // );
-                                OverlapKind::Conflicting
-                            };
-
-                            self.connectivity
-                                .interactions
-                                .push(Interaction {
-                                          partner_lane: other_id,
-                                          start: entry_distance,
-                                          partner_start: other_entry_distance
-                                              .min(other_exit_distance),
-                                          kind: InteractionKind::Overlap {
-                                              end: exit_distance,
-                                              partner_end: other_exit_distance
-                                                  .max(other_entry_distance),
-                                              kind: overlap_kind,
-                                          },
-                                      });
-                        } else {
-                            panic!("both entry and exit should exist")
-                        }
-                    }
-
-
-                    if reply_needed {
-                        other_id <<
-                        ConnectOverlaps {
-                            other_id: self.id(),
-                            other_path: self.construction.path.clone(),
-                            reply_needed: false,
-                        };
-                    }
-                    Fate::Live
-                })
-            }
-        }
-    }
-}
-
 #[derive(Compact, Clone)]
 pub struct ConnectToTransfer {
     other_id: ID,
-}
-
-impl Recipient<ConnectToTransfer> for Lane {
-    fn receive(&mut self, msg: &ConnectToTransfer) -> Fate {
-        match *msg {
-            ConnectToTransfer { other_id } => {
-                other_id <<
-                ConnectTransferToNormal {
-                    other_id: self.id(),
-                    other_path: self.construction.path.clone(),
-                };
-                Fate::Live
-            }
-        }
-    }
 }
 
 #[derive(Compact, Clone)]
@@ -360,98 +520,8 @@ pub struct ConnectTransferToNormal {
     other_path: CPath,
 }
 
-impl Recipient<ConnectTransferToNormal> for TransferLane {
-    #[inline(never)]
-    fn receive(&mut self, msg: &ConnectTransferToNormal) -> Fate {
-        match *msg {
-            ConnectTransferToNormal {
-                other_id,
-                ref other_path,
-            } => {
-                let projections = (other_path.project(self.construction.path.start()),
-                                   other_path.project(self.construction.path.end()));
-                if let (Some(self_start_on_other_distance), Some(self_end_on_other_distance)) =
-                    projections {
-                    if self_start_on_other_distance < self_end_on_other_distance &&
-                       self_end_on_other_distance - self_start_on_other_distance > 6.0 {
-                        let self_start_on_other = other_path.along(self_start_on_other_distance);
-                        let self_end_on_other = other_path.along(self_end_on_other_distance);
-
-                        if self_start_on_other.is_roughly_within(self.construction.path.start(),
-                                                                 3.0) &&
-                           self_end_on_other.is_roughly_within(self.construction.path.end(), 3.0) {
-                            other_id <<
-                            AddTransferLaneInteraction(Interaction {
-                                                           partner_lane: self.id(),
-                                                           start: self_start_on_other_distance,
-                                                           partner_start: 0.0,
-                                                           kind: InteractionKind::Overlap {
-                                                               end: self_start_on_other_distance +
-                                                                    self.construction.length,
-                                                               partner_end:
-                                                                   self.construction.length,
-                                                               kind: OverlapKind::Transfer,
-                                                           },
-                                                       });
-
-                            let mut distance_covered = 0.0;
-                            let distance_map = self.construction
-                                .path
-                                .segments()
-                                .iter()
-                                .map(|segment| {
-                                    distance_covered += segment.length();
-                                    let segment_end_on_other_distance =
-                                        other_path
-                                            .project(segment.end())
-                                            .expect("should contain transfer lane segment end");
-                                    (distance_covered,
-                                     segment_end_on_other_distance - self_start_on_other_distance)
-                                })
-                                .collect();
-
-                            let other_is_right =
-                                (self_start_on_other - self.construction.path.start())
-                                    .dot(&self.construction.path.start_direction().orthogonal()) >
-                                0.0;
-
-                            if other_is_right {
-                                self.connectivity.right = Some((other_id,
-                                                                self_start_on_other_distance));
-                                self.connectivity.right_distance_map = distance_map;
-                            } else {
-                                self.connectivity.left = Some((other_id,
-                                                               self_start_on_other_distance));
-                                self.connectivity.left_distance_map = distance_map;
-                            }
-                        }
-                    }
-                }
-                Fate::Live
-            }
-        }
-    }
-}
-
 #[derive(Copy, Clone)]
 pub struct AddTransferLaneInteraction(Interaction);
-
-impl Recipient<AddTransferLaneInteraction> for Lane {
-    fn receive(&mut self, msg: &AddTransferLaneInteraction) -> Fate {
-        match *msg {
-            AddTransferLaneInteraction(interaction) => {
-                if !self.connectivity
-                        .interactions
-                        .iter()
-                        .any(|existing| existing.partner_lane == interaction.partner_lane) {
-                    self.connectivity.interactions.push(interaction);
-                    super::pathfinding::on_connect(self);
-                }
-                Fate::Live
-            }
-        }
-    }
-}
 
 #[derive(Copy, Clone)]
 pub struct Disconnect {
@@ -460,179 +530,8 @@ pub struct Disconnect {
 #[derive(Copy, Clone)]
 pub struct ConfirmDisconnect;
 
-impl Recipient<Disconnect> for Lane {
-    fn receive(&mut self, msg: &Disconnect) -> Fate {
-        match *msg {
-            Disconnect { other_id } => {
-                let interaction_indices_to_remove = self.connectivity
-                    .interactions
-                    .iter()
-                    .enumerate()
-                    .filter_map(|(i, interaction)| if interaction.partner_lane == other_id {
-                                    Some(i)
-                                } else {
-                                    None
-                                })
-                    .collect::<Vec<_>>();
-                // TODO: Cancel trip
-                self.microtraffic
-                    .cars
-                    .retain(|car| {
-                                !interaction_indices_to_remove
-                                     .contains(&(car.next_hop_interaction as usize))
-                            });
-                self.microtraffic
-                    .obstacles
-                    .retain(|&(_obstacle, from_id)| from_id != other_id);
-                for idx in interaction_indices_to_remove.into_iter().rev() {
-                    self.connectivity.interactions.remove(idx);
-                }
-                super::pathfinding::on_disconnect(self, other_id);
-                other_id << ConfirmDisconnect;
-                Fate::Live
-            }
-        }
-    }
-}
-
-impl Recipient<Disconnect> for TransferLane {
-    fn receive(&mut self, msg: &Disconnect) -> Fate {
-        match *msg {
-            Disconnect { other_id } => {
-                self.connectivity.left = self.connectivity
-                    .left
-                    .and_then(|(left_id, left_start)| if left_id == other_id {
-                                  None
-                              } else {
-                                  Some((left_id, left_start))
-                              });
-                self.connectivity.right = self.connectivity
-                    .right
-                    .and_then(|(right_id, right_start)| if right_id == other_id {
-                                  None
-                              } else {
-                                  Some((right_id, right_start))
-                              });
-                other_id << ConfirmDisconnect;
-                Fate::Live
-            }
-        }
-    }
-}
-
 #[derive(Copy, Clone)]
 pub struct Unbuild {
     pub report_to: ID,
 }
 use self::materialized_reality::ReportLaneUnbuilt;
-
-impl Recipient<Unbuild> for Lane {
-    fn receive(&mut self, msg: &Unbuild) -> Fate {
-        match *msg {
-            Unbuild { report_to } => {
-                let mut disconnects_remaining = 0;
-                for id in self.connectivity
-                        .interactions
-                        .iter()
-                        .map(|interaction| interaction.partner_lane)
-                        .unique() {
-                    id << Disconnect { other_id: self.id() };
-                    disconnects_remaining += 1;
-                }
-                super::rendering::on_unbuild(self);
-                MEMOIZED_BANDS_OUTLINES.with(|memoized_bands_outlines_cell| {
-                                                 let memoized_bands_outlines =
-                                                     unsafe {
-                                                         &mut *memoized_bands_outlines_cell.get()
-                                                     };
-                                                 memoized_bands_outlines.remove(&self.id())
-                                             });
-                if disconnects_remaining == 0 {
-                    report_to << ReportLaneUnbuilt(Some(self.id()));
-                    Fate::Die
-                } else {
-                    self.construction.disconnects_remaining = disconnects_remaining;
-                    self.construction.unbuilding_for = Some(report_to);
-                    Fate::Live
-                }
-            }
-        }
-    }
-}
-
-impl Recipient<Unbuild> for TransferLane {
-    fn receive(&mut self, msg: &Unbuild) -> Fate {
-        match *msg {
-            Unbuild { report_to } => {
-                if let Some((left_id, _)) = self.connectivity.left {
-                    left_id << Disconnect { other_id: self.id() };
-                }
-                if let Some((right_id, _)) = self.connectivity.right {
-                    right_id << Disconnect { other_id: self.id() };
-                }
-                super::rendering::on_unbuild_transfer(self);
-                if self.connectivity.left.is_none() && self.connectivity.right.is_none() {
-                    report_to << ReportLaneUnbuilt(Some(self.id()));
-                    Fate::Die
-                } else {
-                    self.construction.disconnects_remaining = self.connectivity
-                        .left
-                        .into_iter()
-                        .chain(self.connectivity.right)
-                        .count() as
-                                                              u8;
-                    self.construction.unbuilding_for = Some(report_to);
-                    Fate::Live
-                }
-            }
-        }
-    }
-}
-
-impl Recipient<ConfirmDisconnect> for Lane {
-    fn receive(&mut self, _msg: &ConfirmDisconnect) -> Fate {
-        self.construction.disconnects_remaining -= 1;
-        if self.construction.disconnects_remaining == 0 {
-            self.construction
-                .unbuilding_for
-                .expect("should be unbuilding") << ReportLaneUnbuilt(Some(self.id()));
-            Fate::Die
-        } else {
-            Fate::Live
-        }
-    }
-}
-
-impl Recipient<ConfirmDisconnect> for TransferLane {
-    fn receive(&mut self, _msg: &ConfirmDisconnect) -> Fate {
-        self.construction.disconnects_remaining -= 1;
-        if self.construction.disconnects_remaining == 0 {
-            self.construction
-                .unbuilding_for
-                .expect("should be unbuilding") << ReportLaneUnbuilt(Some(self.id()));
-            Fate::Die
-        } else {
-            Fate::Live
-        }
-    }
-}
-
-pub fn setup() {
-    Swarm::<Lane>::handle::<CreateWith<Lane, AdvertiseToTransferAndReport>>();
-    Swarm::<Lane>::handle::<AdvertiseForOverlaps>();
-    Swarm::<Lane>::handle::<Connect>();
-    Swarm::<Lane>::handle::<ConnectToTransfer>();
-    Swarm::<Lane>::handle::<ConnectOverlaps>();
-    Swarm::<Lane>::handle::<AddTransferLaneInteraction>();
-    Swarm::<Lane>::handle::<Disconnect>();
-    Swarm::<Lane>::handle::<Unbuild>();
-    Swarm::<Lane>::handle::<ConfirmDisconnect>();
-
-    Swarm::<TransferLane>::handle::<CreateWith<TransferLane, AdvertiseToTransferAndReport>>();
-    Swarm::<TransferLane>::handle::<ConnectTransferToNormal>();
-    Swarm::<TransferLane>::handle::<Disconnect>();
-    Swarm::<TransferLane>::handle::<Unbuild>();
-    Swarm::<TransferLane>::handle::<ConfirmDisconnect>();
-
-    self::materialized_reality::setup();
-}

--- a/src/game/lanes_and_cars/lane.rs
+++ b/src/game/lanes_and_cars/lane.rs
@@ -1,5 +1,5 @@
 use compact::CVec;
-use kay::{ID, Actor};
+use kay::{ID, ActorSystem};
 use kay::swarm::Swarm;
 use descartes::{N, FiniteCurve};
 use stagemaster::geometry::CPath;
@@ -113,7 +113,7 @@ impl TransferLane {
     }
 }
 
-pub fn setup() {
-    Swarm::<Lane>::register_default();
-    Swarm::<TransferLane>::register_default();
+pub fn setup(system: &mut ActorSystem) {
+    system.add(Swarm::<Lane>::new(), |_| {});
+    system.add(Swarm::<TransferLane>::new(), |_| {});
 }

--- a/src/game/lanes_and_cars/microtraffic/mod.rs
+++ b/src/game/lanes_and_cars/microtraffic/mod.rs
@@ -1,4 +1,4 @@
-use kay::{ID, Recipient, Actor, Fate};
+use kay::{ID, ActorSystem, Fate};
 use kay::swarm::{Swarm, SubActor};
 use compact::CVec;
 use ordered_float::OrderedFloat;
@@ -141,175 +141,554 @@ struct AddObstacles {
 
 use self::pathfinding::RoutingInfo;
 
-impl Recipient<AddCar> for Lane {
-    fn receive(&mut self, msg: &AddCar) -> Fate {
-        match *msg {
-            AddCar { car, .. } => {
-                // TODO: horrible hack to encode it like this
-                let car_forcibly_spawned = *car.as_obstacle.position < 0.0;
+pub fn setup(system: &mut ActorSystem) {
+    system.extend(Swarm::<Lane>::subactors(|mut each_lane| {
+        each_lane.on(|&AddCar { car, .. }, lane, _| {
+            // TODO: horrible hack to encode it like this
+            let car_forcibly_spawned = *car.as_obstacle.position < 0.0;
 
-                let maybe_next_hop_interaction =
-                    self.pathfinding
-                        .routes
-                        .get(car.destination)
-                        .or_else(|| {
-                                     self.pathfinding
-                                         .routes
-                                         .get(car.destination.landmark_destination())
-                                 })
-                        .or_else(|| {
-                            println!("NO ROUTE!");
-                            if car_forcibly_spawned || self.pathfinding.routes.is_empty() {
-                                None
-                            } else {
-                                // pseudorandom, lol
-                                self.pathfinding
-                                    .routes
-                                    .values()
-                                    .nth((car.velocity * 10000.0) as usize %
-                                         self.pathfinding.routes.len())
-                            }
-                        })
-                        .map(|&RoutingInfo { outgoing_idx, .. }| outgoing_idx as usize);
+            let maybe_next_hop_interaction =
+                lane.pathfinding
+                    .routes
+                    .get(car.destination)
+                    .or_else(|| {
+                        lane.pathfinding
+                            .routes
+                            .get(car.destination.landmark_destination())
+                    })
+                    .or_else(|| {
+                        println!("NO ROUTE!");
+                        if car_forcibly_spawned || lane.pathfinding.routes.is_empty() {
+                            None
+                        } else {
+                            // pseudorandom, lol
+                            lane.pathfinding
+                                .routes
+                                .values()
+                                .nth((car.velocity * 10000.0) as usize %
+                                     lane.pathfinding.routes.len())
+                        }
+                    })
+                    .map(|&RoutingInfo { outgoing_idx, .. }| outgoing_idx as usize);
 
-                let spawn_possible = if car_forcibly_spawned {
-                    if self.last_spawn_position > 2.0 {
-                        Some(true)
-                    } else {
-                        None
-                    }
-                } else {
+            let spawn_possible = if car_forcibly_spawned {
+                if lane.last_spawn_position > 2.0 {
                     Some(true)
+                } else {
+                    None
+                }
+            } else {
+                Some(true)
+            };
+
+            if let (Some(next_hop_interaction), Some(_)) =
+                (maybe_next_hop_interaction, spawn_possible) {
+                let routed_car = LaneCar {
+                    next_hop_interaction: next_hop_interaction as u8,
+                    as_obstacle: if car_forcibly_spawned {
+                        lane.last_spawn_position -= 6.0;
+                        car.as_obstacle
+                            .offset_by(-*car.as_obstacle.position)
+                            .offset_by(lane.last_spawn_position + 6.0)
+                    } else {
+                        car.as_obstacle
+                    },
+                    ..car
                 };
 
-                if let (Some(next_hop_interaction), Some(_)) =
-                    (maybe_next_hop_interaction, spawn_possible) {
-                    let routed_car = LaneCar {
-                        next_hop_interaction: next_hop_interaction as u8,
-                        as_obstacle: if car_forcibly_spawned {
-                            self.last_spawn_position -= 6.0;
-                            car.as_obstacle
-                                .offset_by(-*car.as_obstacle.position)
-                                .offset_by(self.last_spawn_position + 6.0)
-                        } else {
-                            car.as_obstacle
-                        },
-                        ..car
+                // TODO: optimize using BinaryHeap?
+                let maybe_next_car_position = lane.microtraffic
+                    .cars
+                    .iter()
+                    .position(|other_car| {
+                        other_car.as_obstacle.position > car.as_obstacle.position
+                    });
+                match maybe_next_car_position {
+                    Some(next_car_position) => {
+                        lane.microtraffic
+                            .cars
+                            .insert(next_car_position, routed_car)
+                    }
+                    None => lane.microtraffic.cars.push(routed_car),
+                }
+            } else {
+                // TODO: cancel trip
+            }
+
+            Fate::Live
+
+        });
+
+        each_lane.on(|&AddObstacles { ref obstacles, from }, lane, _| {
+            lane.microtraffic
+                .obstacles
+                .retain(|&(_, received_from)| received_from != from);
+            lane.microtraffic
+                .obstacles
+                .extend(obstacles.iter().map(|obstacle| (*obstacle, from)));
+            Fate::Live
+        });
+
+        each_lane.on(|&Tick { dt, current_tick }, lane, world| {
+            lane.construction.progress += dt * 400.0;
+
+            let do_traffic = current_tick % TRAFFIC_LOGIC_THROTTLING ==
+                             lane.id().sub_actor_id as usize % TRAFFIC_LOGIC_THROTTLING;
+
+            let old_green = lane.microtraffic.green;
+            lane.microtraffic.yellow_to_red = if lane.microtraffic.timings.is_empty() {
+                true
+            } else {
+                !lane.microtraffic.timings[((current_tick + 100) / 25) %
+                 lane.microtraffic.timings.len()]
+            };
+            lane.microtraffic.yellow_to_green = if lane.microtraffic.timings.is_empty() {
+                true
+            } else {
+                lane.microtraffic.timings[((current_tick + 100) / 25) %
+                lane.microtraffic.timings.len()]
+            };
+            lane.microtraffic.green = if lane.microtraffic.timings.is_empty() {
+                true
+            } else {
+                lane.microtraffic.timings[(current_tick / 25) % lane.microtraffic.timings.len()]
+            };
+
+            // TODO: this is just a hacky way to update new lanes about existing lane's green
+            if old_green != lane.microtraffic.green || do_traffic {
+                for interaction in &lane.connectivity.interactions {
+                    if let Interaction {
+                               kind: InteractionKind::Previous { .. },
+                               partner_lane,
+                               ..
+                           } = *interaction {
+                        world.send(partner_lane,
+                                   SignalChanged {
+                                       from: lane.id(),
+                                       green: lane.microtraffic.green,
+                                   });
+                    }
+                }
+            }
+
+            if current_tick % PATHFINDING_THROTTLING ==
+               lane.id().sub_actor_id as usize % PATHFINDING_THROTTLING {
+                self::pathfinding::tick(lane, world);
+            }
+
+            if do_traffic {
+                // TODO: optimize using BinaryHeap?
+                lane.microtraffic
+                    .obstacles
+                    .sort_by_key(|&(ref obstacle, _id)| obstacle.position);
+
+                let mut obstacles = lane.microtraffic
+                    .obstacles
+                    .iter()
+                    .map(|&(ref obstacle, _id)| obstacle);
+                let mut maybe_next_obstacle = obstacles.next();
+
+                for c in 0..lane.microtraffic.cars.len() {
+                    let next_obstacle = lane.microtraffic
+                        .cars
+                        .get(c + 1)
+                        .map_or(Obstacle::far_ahead(), |car| car.as_obstacle);
+                    let car = &mut lane.microtraffic.cars[c];
+                    let next_car_acceleration = intelligent_acceleration(car, &next_obstacle, 2.0);
+
+                    maybe_next_obstacle = maybe_next_obstacle.and_then(|obstacle| {
+                        let mut following_obstacle = Some(obstacle);
+                        while following_obstacle.is_some() &&
+                              *following_obstacle.unwrap().position < *car.position + 0.1 {
+                            following_obstacle = obstacles.next();
+                        }
+                        following_obstacle
+                    });
+
+                    let next_obstacle_acceleration = if let Some(next_obstacle) =
+                        maybe_next_obstacle {
+                        intelligent_acceleration(car, next_obstacle, 4.0)
+                    } else {
+                        INFINITY
                     };
 
-                    // TODO: optimize using BinaryHeap?
-                    let maybe_next_car_position = self.microtraffic
-                        .cars
-                        .iter()
-                        .position(|other_car| {
-                                      other_car.as_obstacle.position > car.as_obstacle.position
-                                  });
-                    match maybe_next_car_position {
-                        Some(next_car_position) => {
-                            self.microtraffic
-                                .cars
-                                .insert(next_car_position, routed_car)
+                    car.acceleration = next_car_acceleration.min(next_obstacle_acceleration);
+
+                    if let Interaction {
+                               start,
+                               kind: InteractionKind::Next { green },
+                               ..
+                           } = lane.connectivity.interactions[car.next_hop_interaction as usize] {
+                        if !green {
+                            car.acceleration = car.acceleration
+                                .min(intelligent_acceleration(car,
+                                                              &Obstacle {
+                                                                   position: OrderedFloat(start +
+                                                                                          2.0),
+                                                                   velocity: 0.0,
+                                                                   max_velocity: 0.0,
+                                                               },
+                                                              2.0))
                         }
-                        None => self.microtraffic.cars.push(routed_car),
+                    }
+                }
+            }
+
+            for car in &mut lane.microtraffic.cars {
+                *car.position += dt * car.velocity;
+                car.velocity = (car.velocity + dt * car.acceleration)
+                    .min(car.max_velocity)
+                    .max(0.0);
+            }
+
+            for &mut (ref mut obstacle, _id) in &mut lane.microtraffic.obstacles {
+                *obstacle.position += dt * obstacle.velocity;
+            }
+
+            if lane.microtraffic.cars.len() > 1 {
+                for i in (0..lane.microtraffic.cars.len() - 1).rev() {
+                    lane.microtraffic.cars[i].position =
+                        OrderedFloat((*lane.microtraffic.cars[i].position)
+                                         .min(*lane.microtraffic.cars[i + 1].position));
+                }
+            }
+
+            loop {
+                let maybe_switch_car = lane.microtraffic
+                    .cars
+                    .iter()
+                    .enumerate()
+                    .rev()
+                    .filter_map(|(i, &car)| {
+                        let interaction = lane.connectivity.interactions[car.next_hop_interaction as
+                        usize];
+
+                        match interaction.kind {
+                            InteractionKind::Overlap {
+                                end, kind: OverlapKind::Transfer, ..
+                            } => {
+                                if *car.position > interaction.start &&
+                                   *car.position > end - 300.0 {
+                                    Some((i,
+                                          interaction.partner_lane,
+                                          interaction.start,
+                                          interaction.partner_start))
+                                } else {
+                                    None
+                                }
+                            }
+                            _ => {
+                                if *car.position > interaction.start {
+                                    Some((i,
+                                          interaction.partner_lane,
+                                          interaction.start,
+                                          interaction.partner_start))
+                                } else {
+                                    None
+                                }
+                            }
+                        }
+                    })
+                    .next();
+
+                if let Some((idx_to_remove, next_lane, start, partner_start)) = maybe_switch_car {
+                    let car = lane.microtraffic.cars.remove(idx_to_remove);
+                    if lane.id() != car.destination.node {
+                        world.send(next_lane,
+                                   AddCar {
+                                       car: car.offset_by(partner_start - start),
+                                       from: Some(lane.id()),
+                                   });
                     }
                 } else {
-                    // TODO: cancel trip
+                    break;
                 }
-
-                Fate::Live
             }
-        }
-    }
-}
 
-impl Recipient<AddCar> for TransferLane {
-    fn receive(&mut self, msg: &AddCar) -> Fate {
-        match *msg {
-            AddCar {
-                car,
-                from: Some(from),
-            } => {
-                let from_left = from ==
-                                self.connectivity
-                                    .left
-                                    .expect("should have a left lane")
-                                    .0;
-                let side_multiplier = if from_left { -1.0 } else { 1.0 };
-                let offset = self.interaction_to_self_offset(*car.position, from_left);
-                self.microtraffic
-                    .cars
-                    .push(TransferringLaneCar {
-                              as_lane_car: car.offset_by(offset),
-                              transfer_position: 1.0 * side_multiplier,
-                              transfer_velocity: 0.0,
-                              transfer_acceleration: 0.3 * -side_multiplier,
-                              cancelling: false,
-                          });
-                // TODO: optimize using BinaryHeap?
-                self.microtraffic
-                    .cars
-                    .sort_by_key(|car| car.as_obstacle.position);
-                Fate::Live
+            // ASSUMPTION: only one interaction per Lane/Lane pair
+            for interaction in lane.connectivity.interactions.iter() {
+                let cars = lane.microtraffic.cars.iter();
+
+                if (current_tick + 1) % TRAFFIC_LOGIC_THROTTLING ==
+                   interaction.partner_lane.sub_actor_id as usize % TRAFFIC_LOGIC_THROTTLING {
+                    let maybe_obstacles =
+                        obstacles_for_interaction(interaction,
+                                                  cars,
+                                                  lane.microtraffic.obstacles.iter());
+
+                    if let Some(obstacles) = maybe_obstacles {
+                        world.send(interaction.partner_lane,
+                                   AddObstacles { obstacles: obstacles, from: lane.id() })
+                    }
+                }
             }
-            AddCar { from: None, .. } => panic!("car has to come from somewhere on transfer lane"),
-        }
-    }
-}
 
-impl Recipient<AddObstacles> for Lane {
-    fn receive(&mut self, msg: &AddObstacles) -> Fate {
-        match *msg {
-            AddObstacles {
-                ref obstacles,
-                from,
-            } => {
-                self.microtraffic
-                    .obstacles
-                    .retain(|&(_, received_from)| received_from != from);
-                self.microtraffic
-                    .obstacles
-                    .extend(obstacles.iter().map(|obstacle| (*obstacle, from)));
-                Fate::Live
+            Fate::Live
+        });
+
+        each_lane.on(|&SignalChanged { from, green }, lane, _| {
+            if let Some(interaction) =
+                lane.connectivity
+                    .interactions
+                    .iter_mut()
+                    .find(|interaction| match **interaction {
+                              Interaction {
+                                  partner_lane,
+                                  kind: InteractionKind::Next { .. },
+                                  ..
+                              } => partner_lane == from,
+                              _ => false,
+                          }) {
+                interaction.kind = InteractionKind::Next { green: green }
+            } else {
+                println!("Lane doesn't know about next lane yet");
             }
-        }
-    }
-}
+            Fate::Live
+        })
+    }));
 
-impl Recipient<AddObstacles> for TransferLane {
-    fn receive(&mut self, msg: &AddObstacles) -> Fate {
-        match *msg {
-            AddObstacles {
-                ref obstacles,
-                from,
-            } => {
-                if let (Some((left_id, _)), Some(_)) =
-                    (self.connectivity.left, self.connectivity.right) {
-                    if left_id == from {
-                        self.microtraffic.left_obstacles = obstacles
-                            .iter()
-                            .map(|obstacle| {
-                                     obstacle.offset_by(
-                                    self.interaction_to_self_offset(*obstacle.position, true)
-                                )
-                                 })
-                            .collect();
-                    } else {
-                        self.microtraffic.right_obstacles = obstacles
-                            .iter()
-                            .map(|obstacle| {
-                                     obstacle.offset_by(
-                                    self.interaction_to_self_offset(*obstacle.position, false)
-                                )
-                                 })
-                            .collect();
-                    };
+    system.extend(Swarm::<TransferLane>::subactors(|mut each_t_lane| {
+        each_t_lane.on(|&AddCar { car, from: maybe_from }, lane, _| {
+            let from = maybe_from.expect("car has to come from somewhere on transfer lane");
+
+            let from_left = from ==
+                            lane.connectivity
+                                .left
+                                .expect("should have a left lane")
+                                .0;
+            let side_multiplier = if from_left { -1.0 } else { 1.0 };
+            let offset = lane.interaction_to_self_offset(*car.position, from_left);
+            lane.microtraffic
+                .cars
+                .push(TransferringLaneCar {
+                          as_lane_car: car.offset_by(offset),
+                          transfer_position: 1.0 * side_multiplier,
+                          transfer_velocity: 0.0,
+                          transfer_acceleration: 0.3 * -side_multiplier,
+                          cancelling: false,
+                      });
+            // TODO: optimize using BinaryHeap?
+            lane.microtraffic
+                .cars
+                .sort_by_key(|car| car.as_obstacle.position);
+            Fate::Live
+        });
+
+        each_t_lane.on(|&AddObstacles { ref obstacles, from }, lane, _| {
+            if let (Some((left_id, _)), Some(_)) =
+                (lane.connectivity.left, lane.connectivity.right) {
+                if left_id == from {
+                    lane.microtraffic.left_obstacles = obstacles
+                        .iter()
+                        .map(|obstacle| {
+                            obstacle.offset_by(lane.interaction_to_self_offset(*obstacle.position,
+                                                                               true))
+                        })
+                        .collect();
                 } else {
-                    println!("transfer lane not connected for obstacles yet");
-                }
-                Fate::Live
+                    lane.microtraffic.right_obstacles = obstacles
+                        .iter()
+                        .map(|obstacle| {
+                            obstacle.offset_by(lane.interaction_to_self_offset(*obstacle.position,
+                                                                               false))
+                        })
+                        .collect();
+                };
+            } else {
+                println!("transfer lane not connected for obstacles yet");
             }
-        }
-    }
+            Fate::Live
+        });
+
+        each_t_lane.on(|&Tick { dt, current_tick }, lane, world| {
+            lane.construction.progress += dt * 400.0;
+
+            let do_traffic = current_tick % TRAFFIC_LOGIC_THROTTLING ==
+                             lane.id().sub_actor_id as usize % TRAFFIC_LOGIC_THROTTLING;
+
+            if do_traffic {
+                // TODO: optimize using BinaryHeap?
+                lane.microtraffic
+                    .left_obstacles
+                    .sort_by_key(|obstacle| obstacle.position);
+                lane.microtraffic
+                    .right_obstacles
+                    .sort_by_key(|obstacle| obstacle.position);
+
+                for c in 0..lane.microtraffic.cars.len() {
+                    let (acceleration, dangerous) = {
+                        let car = &lane.microtraffic.cars[c];
+                        let next_car = lane.microtraffic
+                            .cars
+                            .iter()
+                            .find(|other_car| *other_car.position > *car.position)
+                            .map(|other_car| &other_car.as_obstacle);
+
+                        let maybe_next_left_obstacle = if car.transfer_position < 0.3 ||
+                                                          car.transfer_acceleration < 0.0 {
+                            lane.microtraffic
+                                .left_obstacles
+                                .iter()
+                                .find(|obstacle| *obstacle.position + 5.0 > *car.position)
+                        } else {
+                            None
+                        };
+
+                        let maybe_next_right_obstacle = if car.transfer_position > -0.3 ||
+                                                           car.transfer_acceleration > 0.0 {
+                            lane.microtraffic
+                                .right_obstacles
+                                .iter()
+                                .find(|obstacle| *obstacle.position + 5.0 > *car.position)
+                        } else {
+                            None
+                        };
+
+                        let mut dangerous = false;
+                        let next_obstacle_acceleration = *next_car.into_iter()
+                                .chain(maybe_next_left_obstacle)
+                                .chain(maybe_next_right_obstacle)
+                                .chain(&[Obstacle::far_ahead()])
+                                .filter_map(|obstacle| if *obstacle.position <
+                                                          *car.position + 0.1 {
+                                    dangerous = true;
+                                    None
+                                } else {
+                                    Some(OrderedFloat(intelligent_acceleration(car, obstacle, 1.0)))
+                                })
+                                .min()
+                                .unwrap();
+
+                        let transfer_before_end_velocity =
+                            (lane.construction.length + 1.0 - *car.position) / 1.5;
+                        let transfer_before_end_acceleration = transfer_before_end_velocity -
+                                                               car.velocity;
+
+                        (next_obstacle_acceleration.min(transfer_before_end_acceleration),
+                         dangerous)
+                    };
+
+                    let car = &mut lane.microtraffic.cars[c];
+                    car.acceleration = acceleration;
+
+                    if dangerous && !car.cancelling {
+                        car.transfer_acceleration = -car.transfer_acceleration;
+                        car.cancelling = true;
+                    }
+                }
+            }
+
+            for car in &mut lane.microtraffic.cars {
+                *car.position += dt * car.velocity;
+                car.velocity = (car.velocity + dt * car.acceleration)
+                    .min(car.max_velocity)
+                    .max(0.0);
+                car.transfer_position += dt * car.transfer_velocity;
+                car.transfer_velocity += dt * car.transfer_acceleration;
+                if car.transfer_velocity.abs() > car.velocity / 12.0 {
+                    car.transfer_velocity = car.velocity / 12.0 * car.transfer_velocity.signum();
+                }
+            }
+
+            for obstacle in lane.microtraffic
+                    .left_obstacles
+                    .iter_mut()
+                    .chain(lane.microtraffic.right_obstacles.iter_mut()) {
+                *obstacle.position += dt * obstacle.velocity;
+            }
+
+            if lane.microtraffic.cars.len() > 1 {
+                for i in (0..lane.microtraffic.cars.len() - 1).rev() {
+                    if lane.microtraffic.cars[i].position > lane.microtraffic.cars[i + 1].position {
+                        lane.microtraffic.cars.swap(i, i + 1);
+                    }
+                }
+            }
+
+            if let (Some((left, left_start)), Some((right, right_start))) =
+                (lane.connectivity.left, lane.connectivity.right) {
+                let mut i = 0;
+                loop {
+                    let (should_remove, done) = if let Some(car) = lane.microtraffic.cars.get(i) {
+                        if car.transfer_position > 1.0 ||
+                           (*car.position > lane.construction.length &&
+                            car.transfer_acceleration > 0.0) {
+                            world.send(right,
+                            AddCar {
+                                car: car.as_lane_car
+                                    .offset_by(right_start +
+                                               lane.self_to_interaction_offset(*car.position,
+                                                                               false)),
+                                from: Some(lane.id()),
+                            });
+                            (true, false)
+                        } else if car.transfer_position < -1.0 ||
+                                  (*car.position > lane.construction.length &&
+                                   car.transfer_acceleration <= 0.0) {
+                            world.send(left,
+                            AddCar {
+                                car: car.as_lane_car
+                                    .offset_by(left_start +
+                                               lane.self_to_interaction_offset(*car.position,
+                                                                               true)),
+                                from: Some(lane.id()),
+                            });
+                            (true, false)
+                        } else {
+                            i += 1;
+                            (false, false)
+                        }
+                    } else {
+                        (false, true)
+                    };
+                    if done {
+                        break;
+                    }
+                    if should_remove {
+                        lane.microtraffic.cars.remove(i);
+                    }
+                }
+
+                if (current_tick + 1) % TRAFFIC_LOGIC_THROTTLING ==
+                   left.sub_actor_id as usize % TRAFFIC_LOGIC_THROTTLING {
+                    let obstacles = lane.microtraffic
+                        .cars
+                        .iter()
+                        .filter_map(|car| if car.transfer_position < 0.3 ||
+                                             car.transfer_acceleration < 0.0 {
+                                        Some(car.as_obstacle.offset_by(
+                                left_start + lane.self_to_interaction_offset(*car.position, true)
+                            ))
+                                    } else {
+                                        None
+                                    })
+                        .collect();
+                    world.send(left, AddObstacles { obstacles: obstacles, from: lane.id() });
+                }
+
+                if (current_tick + 1) % TRAFFIC_LOGIC_THROTTLING ==
+                   right.sub_actor_id as usize % TRAFFIC_LOGIC_THROTTLING {
+                    let obstacles = lane.microtraffic
+                        .cars
+                        .iter()
+                        .filter_map(|car| if car.transfer_position > -0.3 ||
+                                             car.transfer_acceleration > 0.0 {
+                                        Some(car.as_obstacle.offset_by(
+                                    right_start + lane.self_to_interaction_offset(*car.position,
+                                                                                  false)
+                                ))
+                                    } else {
+                                        None
+                                    })
+                        .collect();
+                    world.send(right,
+                               AddObstacles { obstacles: obstacles, from: lane.id() });
+                }
+            }
+
+            Fate::Live
+        })
+    }))
 }
 
 use core::simulation::Tick;
@@ -321,219 +700,6 @@ const PATHFINDING_THROTTLING: usize = 10;
 pub struct SignalChanged {
     from: ID,
     green: bool,
-}
-
-impl Recipient<Tick> for Lane {
-    fn receive(&mut self, msg: &Tick) -> Fate {
-        match *msg {
-            Tick { dt, current_tick } => {
-                self.construction.progress += dt * 400.0;
-
-                let do_traffic = current_tick % TRAFFIC_LOGIC_THROTTLING ==
-                                 self.id().sub_actor_id as usize % TRAFFIC_LOGIC_THROTTLING;
-
-                let old_green = self.microtraffic.green;
-                self.microtraffic.yellow_to_red = if self.microtraffic.timings.is_empty() {
-                    true
-                } else {
-                    !self.microtraffic.timings[((current_tick + 100) / 25) %
-                     self.microtraffic.timings.len()]
-                };
-                self.microtraffic.yellow_to_green = if self.microtraffic.timings.is_empty() {
-                    true
-                } else {
-                    self.microtraffic.timings[((current_tick + 100) / 25) %
-                    self.microtraffic.timings.len()]
-                };
-                self.microtraffic.green = if self.microtraffic.timings.is_empty() {
-                    true
-                } else {
-                    self.microtraffic.timings[(current_tick / 25) % self.microtraffic.timings.len()]
-                };
-
-                // TODO: this is just a hacky way to update new lanes about existing lane's green
-                if old_green != self.microtraffic.green || do_traffic {
-                    for interaction in &self.connectivity.interactions {
-                        if let Interaction {
-                                   kind: InteractionKind::Previous { .. },
-                                   partner_lane,
-                                   ..
-                               } = *interaction {
-                            partner_lane <<
-                            SignalChanged {
-                                from: self.id(),
-                                green: self.microtraffic.green,
-                            }
-                        }
-                    }
-                }
-
-                if current_tick % PATHFINDING_THROTTLING ==
-                   self.id().sub_actor_id as usize % PATHFINDING_THROTTLING {
-                    self::pathfinding::tick(self);
-                }
-
-                if do_traffic {
-                    // TODO: optimize using BinaryHeap?
-                    self.microtraffic
-                        .obstacles
-                        .sort_by_key(|&(ref obstacle, _id)| obstacle.position);
-
-                    let mut obstacles = self.microtraffic
-                        .obstacles
-                        .iter()
-                        .map(|&(ref obstacle, _id)| obstacle);
-                    let mut maybe_next_obstacle = obstacles.next();
-
-                    for c in 0..self.microtraffic.cars.len() {
-                        let next_obstacle =
-                            self.microtraffic
-                                .cars
-                                .get(c + 1)
-                                .map_or(Obstacle::far_ahead(), |car| car.as_obstacle);
-                        let car = &mut self.microtraffic.cars[c];
-                        let next_car_acceleration =
-                            intelligent_acceleration(car, &next_obstacle, 2.0);
-
-                        maybe_next_obstacle = maybe_next_obstacle.and_then(|obstacle| {
-                            let mut following_obstacle = Some(obstacle);
-                            while following_obstacle.is_some() &&
-                                  *following_obstacle.unwrap().position < *car.position + 0.1 {
-                                following_obstacle = obstacles.next();
-                            }
-                            following_obstacle
-                        });
-
-                        let next_obstacle_acceleration = if let Some(next_obstacle) =
-                            maybe_next_obstacle {
-                            intelligent_acceleration(car, next_obstacle, 4.0)
-                        } else {
-                            INFINITY
-                        };
-
-                        car.acceleration = next_car_acceleration.min(next_obstacle_acceleration);
-
-                        if let Interaction {
-                                   start,
-                                   kind: InteractionKind::Next { green },
-                                   ..
-                               } =
-                            self.connectivity.interactions[car.next_hop_interaction as usize] {
-                            if !green {
-                                car.acceleration =
-                                    car.acceleration
-                                        .min(intelligent_acceleration(car,
-                                                                      &Obstacle {
-                                                                           position:
-                                                                               OrderedFloat(start +
-                                                                                            2.0),
-                                                                           velocity: 0.0,
-                                                                           max_velocity: 0.0,
-                                                                       },
-                                                                      2.0))
-                            }
-                        }
-                    }
-                }
-
-                for car in &mut self.microtraffic.cars {
-                    *car.position += dt * car.velocity;
-                    car.velocity = (car.velocity + dt * car.acceleration)
-                        .min(car.max_velocity)
-                        .max(0.0);
-                }
-
-                for &mut (ref mut obstacle, _id) in &mut self.microtraffic.obstacles {
-                    *obstacle.position += dt * obstacle.velocity;
-                }
-
-                if self.microtraffic.cars.len() > 1 {
-                    for i in (0..self.microtraffic.cars.len() - 1).rev() {
-                        self.microtraffic.cars[i].position =
-                            OrderedFloat((*self.microtraffic.cars[i].position)
-                                             .min(*self.microtraffic.cars[i + 1].position));
-                    }
-                }
-
-                loop {
-                    let maybe_switch_car = self.microtraffic
-                        .cars
-                        .iter()
-                        .enumerate()
-                        .rev()
-                        .filter_map(|(i, &car)| {
-                            let interaction = self.connectivity
-                                .interactions
-                                                  [car.next_hop_interaction as usize];
-
-                            match interaction.kind {
-                                InteractionKind::Overlap { end,
-                                                           kind: OverlapKind::Transfer,
-                                                           .. } => {
-                                    if *car.position > interaction.start &&
-                                       *car.position > end - 300.0 {
-                                        Some((i,
-                                              interaction.partner_lane,
-                                              interaction.start,
-                                              interaction.partner_start))
-                                    } else {
-                                        None
-                                    }
-                                }
-                                _ => {
-                                    if *car.position > interaction.start {
-                                        Some((i,
-                                              interaction.partner_lane,
-                                              interaction.start,
-                                              interaction.partner_start))
-                                    } else {
-                                        None
-                                    }
-                                }
-                            }
-                        })
-                        .next();
-
-                    if let Some((idx_to_remove, next_lane, start, partner_start)) =
-                        maybe_switch_car {
-                        let car = self.microtraffic.cars.remove(idx_to_remove);
-                        if self.id() != car.destination.node {
-                            next_lane <<
-                            AddCar {
-                                car: car.offset_by(partner_start - start),
-                                from: Some(self.id()),
-                            };
-                        }
-                    } else {
-                        break;
-                    }
-                }
-
-                // ASSUMPTION: only one interaction per Lane/Lane pair
-                for interaction in self.connectivity.interactions.iter() {
-                    let cars = self.microtraffic.cars.iter();
-
-                    if (current_tick + 1) % TRAFFIC_LOGIC_THROTTLING ==
-                       interaction.partner_lane.sub_actor_id as usize % TRAFFIC_LOGIC_THROTTLING {
-                        let maybe_obstacles =
-                            obstacles_for_interaction(interaction,
-                                                      cars,
-                                                      self.microtraffic.obstacles.iter());
-
-                        if let Some(obstacles) = maybe_obstacles {
-                            interaction.partner_lane <<
-                            AddObstacles {
-                                obstacles: obstacles,
-                                from: self.id(),
-                            }
-                        }
-                    }
-                }
-
-                Fate::Live
-            }
-        }
-    }
 }
 
 fn obstacles_for_interaction(interaction: &Interaction,
@@ -551,8 +717,8 @@ fn obstacles_for_interaction(interaction: &Interaction,
             Some(match kind {
                      OverlapKind::Parallel => {
                          cars.skip_while(|car: &&LaneCar| {
-                                             *car.position + 2.0 * car.velocity < start
-                                         })
+                    *car.position + 2.0 * car.velocity < start
+                })
                              .take_while(|car: &&LaneCar| *car.position < end)
                              .map(|car| car.as_obstacle.offset_by(-start + partner_start))
                              .collect()
@@ -606,236 +772,4 @@ fn obstacles_for_interaction(interaction: &Interaction,
             // TODO: for looking backwards for merging lanes?
         }
     }
-}
-
-impl Recipient<Tick> for TransferLane {
-    fn receive(&mut self, msg: &Tick) -> Fate {
-        match *msg {
-            Tick { dt, current_tick } => {
-                self.construction.progress += dt * 400.0;
-
-                let do_traffic = current_tick % TRAFFIC_LOGIC_THROTTLING ==
-                                 self.id().sub_actor_id as usize % TRAFFIC_LOGIC_THROTTLING;
-
-                if do_traffic {
-                    // TODO: optimize using BinaryHeap?
-                    self.microtraffic
-                        .left_obstacles
-                        .sort_by_key(|obstacle| obstacle.position);
-                    self.microtraffic
-                        .right_obstacles
-                        .sort_by_key(|obstacle| obstacle.position);
-
-                    for c in 0..self.microtraffic.cars.len() {
-                        let (acceleration, dangerous) = {
-                            let car = &self.microtraffic.cars[c];
-                            let next_car = self.microtraffic
-                                .cars
-                                .iter()
-                                .find(|other_car| *other_car.position > *car.position)
-                                .map(|other_car| &other_car.as_obstacle);
-
-                            let maybe_next_left_obstacle = if car.transfer_position < 0.3 ||
-                                                              car.transfer_acceleration < 0.0 {
-                                self.microtraffic
-                                    .left_obstacles
-                                    .iter()
-                                    .find(|obstacle| *obstacle.position + 5.0 > *car.position)
-                            } else {
-                                None
-                            };
-
-                            let maybe_next_right_obstacle = if car.transfer_position > -0.3 ||
-                                                               car.transfer_acceleration > 0.0 {
-                                self.microtraffic
-                                    .right_obstacles
-                                    .iter()
-                                    .find(|obstacle| *obstacle.position + 5.0 > *car.position)
-                            } else {
-                                None
-                            };
-
-                            let mut dangerous = false;
-                            let next_obstacle_acceleration = *next_car.into_iter()
-                                .chain(maybe_next_left_obstacle)
-                                .chain(maybe_next_right_obstacle)
-                                .chain(&[Obstacle::far_ahead()])
-                                .filter_map(|obstacle| if *obstacle.position <
-                                                          *car.position + 0.1 {
-                                    dangerous = true;
-                                    None
-                                } else {
-                                    Some(OrderedFloat(intelligent_acceleration(car, obstacle, 1.0)))
-                                })
-                                .min()
-                                .unwrap();
-
-                            let transfer_before_end_velocity =
-                                (self.construction.length + 1.0 - *car.position) / 1.5;
-                            let transfer_before_end_acceleration = transfer_before_end_velocity -
-                                                                   car.velocity;
-
-                            (next_obstacle_acceleration.min(transfer_before_end_acceleration),
-                             dangerous)
-                        };
-
-                        let car = &mut self.microtraffic.cars[c];
-                        car.acceleration = acceleration;
-
-                        if dangerous && !car.cancelling {
-                            car.transfer_acceleration = -car.transfer_acceleration;
-                            car.cancelling = true;
-                        }
-                    }
-                }
-
-                for car in &mut self.microtraffic.cars {
-                    *car.position += dt * car.velocity;
-                    car.velocity = (car.velocity + dt * car.acceleration)
-                        .min(car.max_velocity)
-                        .max(0.0);
-                    car.transfer_position += dt * car.transfer_velocity;
-                    car.transfer_velocity += dt * car.transfer_acceleration;
-                    if car.transfer_velocity.abs() > car.velocity / 12.0 {
-                        car.transfer_velocity = car.velocity / 12.0 *
-                                                car.transfer_velocity.signum();
-                    }
-                }
-
-                for obstacle in self.microtraffic
-                        .left_obstacles
-                        .iter_mut()
-                        .chain(self.microtraffic.right_obstacles.iter_mut()) {
-                    *obstacle.position += dt * obstacle.velocity;
-                }
-
-                if self.microtraffic.cars.len() > 1 {
-                    for i in (0..self.microtraffic.cars.len() - 1).rev() {
-                        if self.microtraffic.cars[i].position >
-                           self.microtraffic.cars[i + 1].position {
-                            self.microtraffic.cars.swap(i, i + 1);
-                        }
-                    }
-                }
-
-                if let (Some((left, left_start)), Some((right, right_start))) =
-                    (self.connectivity.left, self.connectivity.right) {
-                    let mut i = 0;
-                    loop {
-                        let (should_remove, done) =
-                            if let Some(car) = self.microtraffic.cars.get(i) {
-                                if car.transfer_position > 1.0 ||
-                                   (*car.position > self.construction.length &&
-                                    car.transfer_acceleration > 0.0) {
-                                    right << AddCar{car: car.as_lane_car.offset_by(
-                                right_start + self.self_to_interaction_offset(*car.position, false)
-                            ), from: Some(self.id())};
-                                    (true, false)
-                                } else if car.transfer_position < -1.0 ||
-                                          (*car.position > self.construction.length &&
-                                           car.transfer_acceleration <= 0.0) {
-                                    left << AddCar{car: car.as_lane_car.offset_by(
-                                left_start + self.self_to_interaction_offset(*car.position, true)
-                            ), from: Some(self.id())};
-                                    (true, false)
-                                } else {
-                                    i += 1;
-                                    (false, false)
-                                }
-                            } else {
-                                (false, true)
-                            };
-                        if done {
-                            break;
-                        }
-                        if should_remove {
-                            self.microtraffic.cars.remove(i);
-                        }
-                    }
-
-                    if (current_tick + 1) % TRAFFIC_LOGIC_THROTTLING ==
-                       left.sub_actor_id as usize % TRAFFIC_LOGIC_THROTTLING {
-                        let obstacles = self.microtraffic
-                            .cars
-                            .iter()
-                            .filter_map(|car| if car.transfer_position < 0.3 ||
-                                                 car.transfer_acceleration < 0.0 {
-                                            Some(car.as_obstacle.offset_by(
-                                left_start + self.self_to_interaction_offset(*car.position, true)
-                            ))
-                                        } else {
-                                            None
-                                        })
-                            .collect();
-                        left <<
-                        AddObstacles {
-                            obstacles: obstacles,
-                            from: self.id(),
-                        };
-                    }
-
-                    if (current_tick + 1) % TRAFFIC_LOGIC_THROTTLING ==
-                       right.sub_actor_id as usize % TRAFFIC_LOGIC_THROTTLING {
-                        let obstacles = self.microtraffic
-                            .cars
-                            .iter()
-                            .filter_map(|car| if car.transfer_position > -0.3 ||
-                                                 car.transfer_acceleration > 0.0 {
-                                            Some(car.as_obstacle.offset_by(
-                                    right_start + self.self_to_interaction_offset(*car.position,
-                                                                                  false)
-                                ))
-                                        } else {
-                                            None
-                                        })
-                            .collect();
-                        right <<
-                        AddObstacles {
-                            obstacles: obstacles,
-                            from: self.id(),
-                        };
-                    }
-                }
-
-                Fate::Live
-            }
-        }
-    }
-}
-
-impl Recipient<SignalChanged> for Lane {
-    fn receive(&mut self, msg: &SignalChanged) -> Fate {
-        match *msg {
-            SignalChanged { from, green } => {
-                if let Some(interaction) =
-                    self.connectivity
-                        .interactions
-                        .iter_mut()
-                        .find(|interaction| match **interaction {
-                                  Interaction {
-                                      partner_lane,
-                                      kind: InteractionKind::Next { .. },
-                                      ..
-                                  } => partner_lane == from,
-                                  _ => false,
-                              }) {
-                    interaction.kind = InteractionKind::Next { green: green }
-                } else {
-                    println!("Lane doesn't know about next lane yet");
-                }
-                Fate::Live
-            }
-        }
-    }
-}
-
-pub fn setup() {
-    Swarm::<Lane>::handle::<AddCar>();
-    Swarm::<Lane>::handle::<AddObstacles>();
-    Swarm::<Lane>::handle::<Tick>();
-    Swarm::<Lane>::handle::<SignalChanged>();
-
-    Swarm::<TransferLane>::handle::<AddCar>();
-    Swarm::<TransferLane>::handle::<AddObstacles>();
-    Swarm::<TransferLane>::handle::<Tick>();
 }

--- a/src/game/lanes_and_cars/mod.rs
+++ b/src/game/lanes_and_cars/mod.rs
@@ -7,14 +7,16 @@ pub mod rendering;
 pub mod planning;
 pub mod pathfinding;
 
-pub fn setup() {
-    self::lane::setup();
-    self::construction::setup();
-    self::microtraffic::setup();
-    self::pathfinding::setup();
+use kay::ActorSystem;
+
+pub fn setup(system: &mut ActorSystem) {
+    self::lane::setup(system);
+    self::construction::setup(system);
+    self::microtraffic::setup(system);
+    self::pathfinding::setup(system);
 }
 
-pub fn setup_ui() {
-    rendering::setup();
-    planning::setup();
+pub fn setup_ui(system: &mut ActorSystem) {
+    rendering::setup(system);
+    planning::setup(system);
 }

--- a/src/game/lanes_and_cars/pathfinding/mod.rs
+++ b/src/game/lanes_and_cars/pathfinding/mod.rs
@@ -1,5 +1,5 @@
 use compact::{CDict, CVec};
-use kay::{ID, Actor, Recipient, Fate};
+use kay::{ID, ActorSystem, Fate, World};
 use kay::swarm::{Swarm, SubActor};
 use stagemaster::geometry::AnyShape;
 use descartes::Band;
@@ -28,10 +28,7 @@ pub struct Destination {
 
 impl Destination {
     fn landmark(landmark: ID) -> Self {
-        Destination {
-            landmark: landmark,
-            node: landmark,
-        }
+        Destination { landmark: landmark, node: landmark }
     }
     pub fn is_landmark(&self) -> bool {
         self.landmark == self.node
@@ -53,13 +50,13 @@ pub struct RoutingInfo {
 use stagemaster::{UserInterface, AddInteractable};
 const DEBUG_CARS_ON_LANES: bool = false;
 
-pub fn on_build(lane: &mut Lane) {
+pub fn on_build(lane: &mut Lane, world: &mut World) {
     lane.pathfinding.as_destination = None;
     if DEBUG_CARS_ON_LANES {
-        UserInterface::id() <<
-        AddInteractable(lane.id(),
-                        AnyShape::Band(Band::new(lane.construction.path.clone(), 3.0)),
-                        5);
+        world.send_to_id_of::<UserInterface, _>(
+                   AddInteractable(lane.id(),
+                                   AnyShape::Band(Band::new(lane.construction.path.clone(), 3.0)),
+                                   5));
     }
 }
 
@@ -85,18 +82,18 @@ pub fn on_disconnect(lane: &mut Lane, disconnected_id: ID) {
 const MIN_LANDMARK_INCOMING: usize = 3;
 const ROUTING_TIMEOUT_AFTER_CHANGE: u16 = 15;
 
-pub fn tick(lane: &mut Lane) {
+pub fn tick(lane: &mut Lane, world: &mut World) {
     if let Some(as_destination) = lane.pathfinding.as_destination {
         for successor in successors(lane) {
-            successor <<
-            JoinLandmark {
-                from: lane.id(),
-                join_as: Destination {
-                    landmark: as_destination.landmark,
-                    node: successor,
-                },
-                hops_from_landmark: lane.pathfinding.hops_from_landmark + 1,
-            }
+            world.send(successor,
+                       JoinLandmark {
+                           from: lane.id(),
+                           join_as: Destination {
+                               landmark: as_destination.landmark,
+                               node: successor,
+                           },
+                           hops_from_landmark: lane.pathfinding.hops_from_landmark + 1,
+                       })
         }
     } else if !lane.connectivity.on_intersection &&
               predecessors(lane).count() >= MIN_LANDMARK_INCOMING {
@@ -117,22 +114,19 @@ pub fn tick(lane: &mut Lane) {
     } else {
         if lane.pathfinding.query_routes_next_tick {
             for successor in successors(lane) {
-                successor <<
-                QueryRoutes {
-                    requester: lane.id(),
-                    is_transfer: false,
-                };
+                world.send(successor,
+                           QueryRoutes { requester: lane.id(), is_transfer: false });
             }
             lane.pathfinding.query_routes_next_tick = false;
         }
 
         if !lane.pathfinding.tell_to_forget_next_tick.is_empty() {
             for (_, predecessor, _) in predecessors(lane) {
-                predecessor <<
-                ForgetRoutes {
-                    forget: lane.pathfinding.tell_to_forget_next_tick.clone(),
-                    from: lane.id(),
-                }
+                world.send(predecessor,
+                           ForgetRoutes {
+                               forget: lane.pathfinding.tell_to_forget_next_tick.clone(),
+                               from: lane.id(),
+                           })
             }
             lane.pathfinding.tell_to_forget_next_tick.clear();
         }
@@ -144,35 +138,37 @@ pub fn tick(lane: &mut Lane) {
                 } else {
                     lane.construction.length
                 };
-                predecessor <<
-                ShareRoutes {
-                    new_routes: lane.pathfinding
-                        .routes
-                        .pairs()
-                        .filter_map(|(&destination,
-                                      &RoutingInfo {
-                                           distance,
-                                           distance_hops,
-                                           ..
-                                       })| {
-                            if true
-                            // fresh
-                            {
-                                Some((destination, (distance + self_cost, distance_hops + 1)))
-                            } else {
-                                None
-                            }
-                        })
-                        .chain(if lane.connectivity.on_intersection {
-                                   None
-                               } else {
-                                   lane.pathfinding
-                                       .as_destination
-                                       .map(|destination| (destination, (self_cost, 0)))
-                               })
-                        .collect(),
-                    from: lane.id(),
-                };
+                world.send(predecessor,
+                           ShareRoutes {
+                               new_routes: lane.pathfinding
+                                   .routes
+                                   .pairs()
+                                   .filter_map(|(&destination,
+                                                 &RoutingInfo {
+                                                      distance,
+                                                      distance_hops,
+                                                      ..
+                                                  })| {
+                    if true
+                    // fresh
+                    {
+                        Some((destination, (distance + self_cost, distance_hops + 1)))
+                    } else {
+                        None
+                    }
+                })
+                                   .chain(if lane.connectivity.on_intersection {
+                                              None
+                                          } else {
+                                              lane.pathfinding
+                                                  .as_destination
+                                                  .map(|destination| {
+                        (destination, (self_cost, 0))
+                    })
+                                          })
+                                   .collect(),
+                               from: lane.id(),
+                           });
             }
             for routing_info in lane.pathfinding.routes.values_mut() {
                 routing_info.fresh = false;
@@ -232,74 +228,199 @@ pub struct JoinLandmark {
 
 const IDEAL_LANDMARK_RADIUS: u8 = 3;
 
-impl Recipient<JoinLandmark> for Lane {
-    fn receive(&mut self, msg: &JoinLandmark) -> Fate {
-        match *msg {
-            JoinLandmark {
-                join_as,
-                hops_from_landmark,
-                from,
-            } => {
-                let join = self.pathfinding
-                    .as_destination
-                    .map(|self_destination| {
-                        join_as != self_destination &&
-                        (if self_destination.is_landmark() {
-                             hops_from_landmark < IDEAL_LANDMARK_RADIUS &&
-                             join_as.landmark.sub_actor_id < self.id().sub_actor_id
-                         } else {
-                             hops_from_landmark < self.pathfinding.hops_from_landmark ||
-                             self.pathfinding
-                                 .learned_landmark_from
-                                 .map(|learned_from| learned_from == from)
-                                 .unwrap_or(false)
-                         })
-                    })
-                    .unwrap_or(true);
-                if join {
-                    self.pathfinding = PathfindingInfo {
-                        as_destination: Some(join_as),
-                        learned_landmark_from: Some(from),
-                        hops_from_landmark: hops_from_landmark,
-                        routes: CDict::new(),
-                        routes_changed: true,
-                        query_routes_next_tick: true,
-                        tell_to_forget_next_tick: self.pathfinding
-                            .routes
-                            .keys()
-                            .cloned()
-                            .chain(self.pathfinding.as_destination.into_iter())
-                            .collect(),
-                        routing_timeout: ROUTING_TIMEOUT_AFTER_CHANGE,
-                    };
-                }
-                Fate::Live
-            }
-        }
-    }
-}
-
-impl Recipient<JoinLandmark> for TransferLane {
-    fn receive(&mut self, msg: &JoinLandmark) -> Fate {
-        match *msg {
-            JoinLandmark {
-                join_as,
-                hops_from_landmark,
-                from,
-            } => {
-                self.other_side(from) <<
-                JoinLandmark {
-                    join_as: Destination {
-                        landmark: join_as.landmark,
-                        node: self.other_side(from),
-                    },
+pub fn setup(system: &mut ActorSystem) {
+    system.extend(Swarm::<Lane>::subactors(|mut each_lane| {
+        each_lane.on(|&JoinLandmark { join_as, hops_from_landmark, from }, lane, _| {
+            let join = lane.pathfinding
+                .as_destination
+                .map(|self_destination| {
+                    join_as != self_destination &&
+                    (if self_destination.is_landmark() {
+                         hops_from_landmark < IDEAL_LANDMARK_RADIUS &&
+                         join_as.landmark.sub_actor_id < lane.id().sub_actor_id
+                     } else {
+                         hops_from_landmark < lane.pathfinding.hops_from_landmark ||
+                         lane.pathfinding
+                             .learned_landmark_from
+                             .map(|learned_from| learned_from == from)
+                             .unwrap_or(false)
+                     })
+                })
+                .unwrap_or(true);
+            if join {
+                lane.pathfinding = PathfindingInfo {
+                    as_destination: Some(join_as),
+                    learned_landmark_from: Some(from),
                     hops_from_landmark: hops_from_landmark,
-                    from: self.id(),
+                    routes: CDict::new(),
+                    routes_changed: true,
+                    query_routes_next_tick: true,
+                    tell_to_forget_next_tick: lane.pathfinding
+                        .routes
+                        .keys()
+                        .cloned()
+                        .chain(lane.pathfinding.as_destination.into_iter())
+                        .collect(),
+                    routing_timeout: ROUTING_TIMEOUT_AFTER_CHANGE,
                 };
-                Fate::Live
             }
-        }
-    }
+            Fate::Live
+        });
+
+        each_lane.on(|&QueryRoutes { requester, is_transfer }, lane, world| {
+            let self_cost = if is_transfer {
+                0.0
+            } else {
+                lane.construction.length
+            };
+            world.send(requester,
+                       ShareRoutes {
+                           new_routes: lane.pathfinding
+                               .routes
+                               .pairs()
+                               .map(|(&destination,
+                                      &RoutingInfo { distance, distance_hops, .. })| {
+                (destination, (distance + self_cost, distance_hops + 1))
+            })
+                               .chain(if lane.connectivity.on_intersection {
+                                          None
+                                      } else {
+                                          lane.pathfinding
+                                              .as_destination
+                                              .map(|destination| (destination, (self_cost, 0)))
+                                      })
+                               .collect(),
+                           from: lane.id(),
+                       });
+            Fate::Live
+        });
+
+        each_lane.on(|&ShareRoutes { ref new_routes, from }, lane, _| {
+            if let Some(from_interaction_idx) =
+                lane.connectivity
+                    .interactions
+                    .iter()
+                    .position(|interaction| interaction.partner_lane == from) {
+                for (&destination, &(new_distance, new_distance_hops)) in new_routes.pairs() {
+                    if destination.is_landmark() || new_distance_hops <= IDEAL_LANDMARK_RADIUS ||
+                       lane.pathfinding
+                           .as_destination
+                           .map(|self_dest| self_dest.landmark == destination.landmark)
+                           .unwrap_or(false) {
+                        let insert = lane.pathfinding
+                            .routes
+                            .get_mru(destination)
+                            .map(|&RoutingInfo { distance, .. }| new_distance < distance)
+                            .unwrap_or(true);
+                        if insert {
+                            lane.pathfinding
+                                .routes
+                                .insert(destination,
+                                        RoutingInfo {
+                                            distance: new_distance,
+                                            distance_hops: new_distance_hops,
+                                            outgoing_idx: from_interaction_idx as u8,
+                                            learned_from: from,
+                                            fresh: true,
+                                        });
+                            lane.pathfinding.routes_changed = true;
+                        }
+                    }
+                }
+            } else {
+                println!("{:?} not yet connected to {:?}", lane.id(), from);
+            }
+            Fate::Live
+        });
+
+        each_lane.on(|&ForgetRoutes { ref forget, from }, lane, _| {
+            let mut forgotten = CVec::<Destination>::new();
+            for destination_to_forget in forget.iter() {
+                let forget = if let Some(routing_info) =
+                    lane.pathfinding.routes.get(*destination_to_forget) {
+                    routing_info.learned_from == from
+                } else {
+                    false
+                };
+                if forget {
+                    lane.pathfinding.routes.remove(*destination_to_forget);
+                    if destination_to_forget.is_landmark() {
+                        lane.microtraffic
+                            .cars
+                            .retain(|car| {
+                                car.destination.landmark != destination_to_forget.landmark
+                            })
+                    } else {
+                        lane.microtraffic
+                            .cars
+                            .retain(|car| &car.destination != destination_to_forget)
+                    }
+                    forgotten.push(*destination_to_forget);
+                }
+            }
+            lane.pathfinding.tell_to_forget_next_tick = forgotten;
+            Fate::Live
+        });
+
+        each_lane.on(|&QueryAsDestination { requester }, lane, world| {
+            world.send(requester,
+                       TellAsDestination {
+                           id: lane.id(),
+                           as_destination: lane.pathfinding.as_destination,
+                       });
+            Fate::Live
+        })
+    }));
+
+    system.extend(Swarm::<TransferLane>::subactors(|mut each_t_lane| {
+        each_t_lane.on(|&JoinLandmark { join_as, hops_from_landmark, from }, lane, world| {
+            world.send(lane.other_side(from),
+                       JoinLandmark {
+                           join_as: Destination {
+                               landmark: join_as.landmark,
+                               node: lane.other_side(from),
+                           },
+                           hops_from_landmark: hops_from_landmark,
+                           from: lane.id(),
+                       });
+            Fate::Live
+        });
+
+        each_t_lane.on(|&QueryRoutes { requester, .. }, lane, world| {
+            world.send(lane.other_side(requester),
+                       QueryRoutes { requester: lane.id(), is_transfer: true });
+            Fate::Live
+        });
+
+        each_t_lane.on(|&ShareRoutes { ref new_routes, from }, lane, world| {
+            world.send(lane.other_side(from),
+                       ShareRoutes {
+                           new_routes: new_routes
+                               .pairs()
+                               .map(|(&destination, &(distance, hops))| {
+                (destination,
+                 (distance +
+                  if from == lane.connectivity.left.expect("should have left").0 {
+                      LANE_CHANGE_COST_RIGHT
+                  } else {
+                      LANE_CHANGE_COST_LEFT
+                  },
+                  hops))
+            })
+                               .collect(),
+                           from: lane.id(),
+                       });
+            Fate::Live
+        });
+
+        each_t_lane.on(|&ForgetRoutes { ref forget, from }, lane, world| {
+            world.send(lane.other_side(from),
+                       ForgetRoutes { forget: forget.clone(), from: lane.id() });
+            Fate::Live
+        })
+    }));
+
+    trip::setup(system);
 }
 
 #[derive(Copy, Clone)]
@@ -308,204 +429,19 @@ pub struct QueryRoutes {
     is_transfer: bool,
 }
 
-impl Recipient<QueryRoutes> for Lane {
-    fn receive(&mut self, msg: &QueryRoutes) -> Fate {
-        match *msg {
-            QueryRoutes {
-                requester,
-                is_transfer,
-            } => {
-                let self_cost = if is_transfer {
-                    0.0
-                } else {
-                    self.construction.length
-                };
-                requester <<
-                ShareRoutes {
-                    new_routes: self.pathfinding
-                        .routes
-                        .pairs()
-                        .map(|(&destination,
-                               &RoutingInfo {
-                                    distance,
-                                    distance_hops,
-                                    ..
-                                })| {
-                                 (destination, (distance + self_cost, distance_hops + 1))
-                             })
-                        .chain(if self.connectivity.on_intersection {
-                                   None
-                               } else {
-                                   self.pathfinding
-                                       .as_destination
-                                       .map(|destination| (destination, (self_cost, 0)))
-                               })
-                        .collect(),
-                    from: self.id(),
-                };
-                Fate::Live
-            }
-        }
-    }
-}
-
-impl Recipient<QueryRoutes> for TransferLane {
-    fn receive(&mut self, msg: &QueryRoutes) -> Fate {
-        match *msg {
-            QueryRoutes { requester, .. } => {
-                self.other_side(requester) <<
-                QueryRoutes {
-                    requester: self.id(),
-                    is_transfer: true,
-                };
-                Fate::Live
-            }
-        }
-    }
-}
-
 #[derive(Compact, Clone)]
 pub struct ShareRoutes {
     new_routes: CDict<Destination, (f32, u8)>,
     from: ID,
 }
 
-impl Recipient<ShareRoutes> for Lane {
-    fn receive(&mut self, msg: &ShareRoutes) -> Fate {
-        match *msg {
-            ShareRoutes {
-                ref new_routes,
-                from,
-            } => {
-                if let Some(from_interaction_idx) =
-                    self.connectivity
-                        .interactions
-                        .iter()
-                        .position(|interaction| interaction.partner_lane == from) {
-                    for (&destination, &(new_distance, new_distance_hops)) in new_routes.pairs() {
-                        if destination.is_landmark() ||
-                           new_distance_hops <= IDEAL_LANDMARK_RADIUS ||
-                           self.pathfinding
-                               .as_destination
-                               .map(|self_dest| self_dest.landmark == destination.landmark)
-                               .unwrap_or(false) {
-                            let insert = self.pathfinding
-                                .routes
-                                .get_mru(destination)
-                                .map(|&RoutingInfo { distance, .. }| new_distance < distance)
-                                .unwrap_or(true);
-                            if insert {
-                                self.pathfinding
-                                    .routes
-                                    .insert(destination,
-                                            RoutingInfo {
-                                                distance: new_distance,
-                                                distance_hops: new_distance_hops,
-                                                outgoing_idx: from_interaction_idx as u8,
-                                                learned_from: from,
-                                                fresh: true,
-                                            });
-                                self.pathfinding.routes_changed = true;
-                            }
-                        }
-                    }
-                } else {
-                    println!("{:?} not yet connected to {:?}", self.id(), from);
-                }
-                Fate::Live
-            }
-        }
-    }
-}
-
 const LANE_CHANGE_COST_LEFT: f32 = 5.0;
 const LANE_CHANGE_COST_RIGHT: f32 = 3.0;
-
-impl Recipient<ShareRoutes> for TransferLane {
-    fn receive(&mut self, msg: &ShareRoutes) -> Fate {
-        match *msg {
-            ShareRoutes {
-                ref new_routes,
-                from,
-            } => {
-                self.other_side(from) <<
-                ShareRoutes {
-                    new_routes: new_routes
-                        .pairs()
-                        .map(|(&destination, &(distance, hops))| {
-                            (destination,
-                             (distance +
-                              if from == self.connectivity.left.expect("should have left").0 {
-                                  LANE_CHANGE_COST_RIGHT
-                              } else {
-                                  LANE_CHANGE_COST_LEFT
-                              },
-                              hops))
-                        })
-                        .collect(),
-                    from: self.id(),
-                };
-                Fate::Live
-            }
-        }
-    }
-}
 
 #[derive(Compact, Clone)]
 pub struct ForgetRoutes {
     forget: CVec<Destination>,
     from: ID,
-}
-
-impl Recipient<ForgetRoutes> for Lane {
-    fn receive(&mut self, msg: &ForgetRoutes) -> Fate {
-        match *msg {
-            ForgetRoutes { ref forget, from } => {
-                let mut forgotten = CVec::<Destination>::new();
-                for destination_to_forget in forget.iter() {
-                    let forget = if let Some(routing_info) =
-                        self.pathfinding.routes.get(*destination_to_forget) {
-                        routing_info.learned_from == from
-                    } else {
-                        false
-                    };
-                    if forget {
-                        self.pathfinding.routes.remove(*destination_to_forget);
-                        if destination_to_forget.is_landmark() {
-                            self.microtraffic
-                                .cars
-                                .retain(|car| {
-                                            car.destination.landmark !=
-                                            destination_to_forget.landmark
-                                        })
-                        } else {
-                            self.microtraffic
-                                .cars
-                                .retain(|car| &car.destination != destination_to_forget)
-                        }
-                        forgotten.push(*destination_to_forget);
-                    }
-                }
-                self.pathfinding.tell_to_forget_next_tick = forgotten;
-                Fate::Live
-            }
-        }
-    }
-}
-
-impl Recipient<ForgetRoutes> for TransferLane {
-    fn receive(&mut self, msg: &ForgetRoutes) -> Fate {
-        match *msg {
-            ForgetRoutes { ref forget, from } => {
-                self.other_side(from) <<
-                ForgetRoutes {
-                    forget: forget.clone(),
-                    from: self.id(),
-                };
-                Fate::Live
-            }
-        }
-    }
 }
 
 #[derive(Copy, Clone)]
@@ -516,36 +452,4 @@ pub struct QueryAsDestination {
 pub struct TellAsDestination {
     id: ID,
     as_destination: Option<Destination>,
-}
-
-impl Recipient<QueryAsDestination> for Lane {
-    fn receive(&mut self, msg: &QueryAsDestination) -> Fate {
-        match *msg {
-            QueryAsDestination { requester } => {
-                requester <<
-                TellAsDestination {
-                    id: self.id(),
-                    as_destination: self.pathfinding.as_destination,
-                };
-                Fate::Live
-            }
-        }
-    }
-}
-
-use kay::swarm::ToRandom;
-
-pub fn setup() {
-    Swarm::<Lane>::handle::<JoinLandmark>();
-    Swarm::<TransferLane>::handle::<JoinLandmark>();
-    Swarm::<Lane>::handle::<QueryRoutes>();
-    Swarm::<TransferLane>::handle::<QueryRoutes>();
-    Swarm::<Lane>::handle::<ShareRoutes>();
-    Swarm::<TransferLane>::handle::<ShareRoutes>();
-    Swarm::<Lane>::handle::<ForgetRoutes>();
-    Swarm::<TransferLane>::handle::<ForgetRoutes>();
-    Swarm::<Lane>::handle::<QueryAsDestination>();
-    Swarm::<Lane>::handle::<ToRandom<::stagemaster::Event3d>>();
-
-    trip::setup();
 }

--- a/src/game/lanes_and_cars/planning/current_plan/addable.rs
+++ b/src/game/lanes_and_cars/planning/current_plan/addable.rs
@@ -1,5 +1,5 @@
-use kay::{ID, Recipient, Actor, Fate};
-use kay::swarm::{Swarm, SubActor, CreateWith};
+use kay::{ID, ActorSystem, Fate};
+use kay::swarm::{Swarm, SubActor};
 use descartes::Band;
 use stagemaster::geometry::{CPath, AnyShape};
 
@@ -13,64 +13,55 @@ pub struct Addable {
 
 impl Addable {
     pub fn new(path: CPath) -> Self {
-        Addable {
-            _id: None,
-            path: path,
-        }
+        Addable { _id: None, path: path }
     }
 }
 
 use super::InitInteractable;
 use stagemaster::{UserInterface, AddInteractable};
 
-impl Recipient<InitInteractable> for Addable {
-    fn receive(&mut self, _msg: &InitInteractable) -> Fate {
-        UserInterface::id() <<
-        AddInteractable(self.id(),
-                        AnyShape::Band(Band::new(self.path.clone(), 3.0)),
-                        3);
-        Fate::Live
-    }
+pub fn setup(system: &mut ActorSystem) {
+    system.add(Swarm::<Addable>::new(),
+               Swarm::<Addable>::subactors(|mut each_addable| {
+        let ui_id = each_addable.world().id::<UserInterface>();
+        let cp_id = each_addable.world().id::<CurrentPlan>();
+
+        each_addable.on_create_with(move |_: &InitInteractable, addable, world| {
+            world.send(ui_id,
+                       AddInteractable(addable.id(),
+                                       AnyShape::Band(Band::new(addable.path.clone(), 3.0)),
+                                       3));
+            Fate::Live
+        });
+
+        each_addable.on(move |_: &ClearInteractable, addable, world| {
+            world.send(ui_id, RemoveInteractable(addable.id()));
+            Fate::Die
+        });
+
+        each_addable.on(move |event, _, world| {
+            match *event {
+                Event3d::HoverStarted { .. } |
+                Event3d::HoverOngoing { .. } => {
+                    world.send(cp_id,
+                               ChangeIntent(Intent::CreateNextLane, IntentProgress::Preview));
+                }
+                Event3d::HoverStopped => {
+                    world.send(cp_id, ChangeIntent(Intent::None, IntentProgress::Preview));
+                }
+                Event3d::DragStarted { .. } => {
+                    world.send(cp_id,
+                               ChangeIntent(Intent::CreateNextLane, IntentProgress::Immediate));
+                }
+                _ => {}
+            };
+            Fate::Live
+        })
+    }));
 }
 
 use super::ClearInteractable;
 use stagemaster::RemoveInteractable;
 
-impl Recipient<ClearInteractable> for Addable {
-    fn receive(&mut self, _msg: &ClearInteractable) -> Fate {
-        UserInterface::id() << RemoveInteractable(self.id());
-        Fate::Die
-    }
-}
-
 use stagemaster::Event3d;
 use super::{ChangeIntent, Intent, IntentProgress};
-
-impl Recipient<Event3d> for Addable {
-    fn receive(&mut self, msg: &Event3d) -> Fate {
-        match *msg {
-            Event3d::HoverStarted { .. } |
-            Event3d::HoverOngoing { .. } => {
-                CurrentPlan::id() << ChangeIntent(Intent::CreateNextLane, IntentProgress::Preview);
-                Fate::Live
-            }
-            Event3d::HoverStopped => {
-                CurrentPlan::id() << ChangeIntent(Intent::None, IntentProgress::Preview);
-                Fate::Live
-            }
-            Event3d::DragStarted { .. } => {
-                CurrentPlan::id() <<
-                ChangeIntent(Intent::CreateNextLane, IntentProgress::Immediate);
-                Fate::Live
-            }
-            _ => Fate::Live,
-        }
-    }
-}
-
-pub fn setup() {
-    Swarm::<Addable>::register_default();
-    Swarm::<Addable>::handle::<CreateWith<Addable, InitInteractable>>();
-    Swarm::<Addable>::handle::<ClearInteractable>();
-    Swarm::<Addable>::handle::<Event3d>();
-}

--- a/src/game/lanes_and_cars/planning/current_plan/apply_intent.rs
+++ b/src/game/lanes_and_cars/planning/current_plan/apply_intent.rs
@@ -467,8 +467,8 @@ fn all_strokes<'a>(plan_delta: &'a PlanDelta,
                    .mapping
                    .pairs()
                    .map(|(old_ref, old_stroke)| {
-                            (SelectableStrokeRef::Built(*old_ref), old_stroke)
-                        }))
+            (SelectableStrokeRef::Built(*old_ref), old_stroke)
+        }))
 }
 
 fn apply_maximize_selection(current: &PlanStep, still_built_strokes: &BuiltStrokes) -> PlanStep {
@@ -476,9 +476,9 @@ fn apply_maximize_selection(current: &PlanStep, still_built_strokes: &BuiltStrok
         .selections
         .pairs()
         .map(|(selection_ref, _)| {
-                 let stroke = selection_ref.get_stroke(&current.plan_delta, still_built_strokes);
-                 (*selection_ref, (0.0, stroke.path().length()))
-             })
+            let stroke = selection_ref.get_stroke(&current.plan_delta, still_built_strokes);
+            (*selection_ref, (0.0, stroke.path().length()))
+        })
         .collect();
     PlanStep {
         selections: new_selections,
@@ -497,9 +497,9 @@ fn apply_move_selection(delta: V2,
         .selections
         .pairs()
         .map(|(&selection_ref, &(start, end))| {
-                 let stroke = selection_ref.get_stroke(&current.plan_delta, still_built_strokes);
-                 (selection_ref, stroke.with_subsection_moved(start, end, delta))
-             })
+            let stroke = selection_ref.get_stroke(&current.plan_delta, still_built_strokes);
+            (selection_ref, stroke.with_subsection_moved(start, end, delta))
+        })
         .collect::<::fnv::FnvHashMap<_, _>>();
 
     #[derive(PartialEq, Eq)]
@@ -712,10 +712,9 @@ fn apply_create_next_lane(current: &PlanStep, still_built_strokes: &BuiltStrokes
         .selections
         .pairs()
         .filter_map(|(&selection_ref, &(start, end))| {
-                        let stroke = selection_ref.get_stroke(&current.plan_delta,
-                                                              still_built_strokes);
-                        stroke.subsection(start, end)
-                    })
+            let stroke = selection_ref.get_stroke(&current.plan_delta, still_built_strokes);
+            stroke.subsection(start, end)
+        })
         .collect::<Vec<_>>();
     let next_lane_strokes = selected_subsections
         .iter()
@@ -724,19 +723,19 @@ fn apply_create_next_lane(current: &PlanStep, still_built_strokes: &BuiltStrokes
                 .nodes()
                 .iter()
                 .map(|node| {
-                         LaneStrokeNode {
-                             position: node.position + node.direction.orthogonal() * LANE_DISTANCE,
-                             direction: node.direction,
-                         }
-                     })
+                    LaneStrokeNode {
+                        position: node.position + node.direction.orthogonal() * LANE_DISTANCE,
+                        direction: node.direction,
+                    }
+                })
                 .collect();
             LaneStroke::new(offset_nodes).ok()
         })
         .filter(|stroke| {
-                    !selected_subsections
-                         .iter()
-                         .any(|subsection| stroke.is_roughly_within(subsection, 0.1))
-                });
+            !selected_subsections
+                 .iter()
+                 .any(|subsection| stroke.is_roughly_within(subsection, 0.1))
+        });
     let mut new_new_strokes = current.plan_delta.new_strokes.clone();
     new_new_strokes.extend(next_lane_strokes);
 

--- a/src/game/lanes_and_cars/planning/current_plan/deselecter.rs
+++ b/src/game/lanes_and_cars/planning/current_plan/deselecter.rs
@@ -1,49 +1,42 @@
-use kay::{Recipient, Actor, Fate};
+use kay::{ActorSystem, Fate};
 use stagemaster::geometry::AnyShape;
 use super::CurrentPlan;
 
 #[derive(Default)]
 pub struct Deselecter;
-impl Actor for Deselecter {}
 
 use super::InitInteractable;
 use stagemaster::{UserInterface, AddInteractable};
 
-impl Recipient<InitInteractable> for Deselecter {
-    fn receive(&mut self, _msg: &InitInteractable) -> Fate {
-        UserInterface::id() << AddInteractable(Self::id(), AnyShape::Everywhere, 2);
-        Fate::Live
-    }
+pub fn setup(system: &mut ActorSystem) {
+    system.add(Deselecter::default(), |mut the_deselecter| {
+        let deselecter_id = the_deselecter.world().id::<Deselecter>();
+        let ui_id = the_deselecter.world().id::<UserInterface>();
+        let cp_id = the_deselecter.world().id::<CurrentPlan>();
+
+        the_deselecter.on(move |_: &InitInteractable, _, world| {
+            world.send(ui_id,
+                       AddInteractable(deselecter_id, AnyShape::Everywhere, 2));
+            Fate::Live
+        });
+
+        the_deselecter.on(move |_: &ClearInteractable, _, world| {
+            world.send(ui_id, RemoveInteractable(deselecter_id));
+            Fate::Die
+        });
+
+        the_deselecter.on(move |&event, _, world| {
+            if let Event3d::DragFinished { .. } = event {
+                world.send(cp_id,
+                           ChangeIntent(Intent::Deselect, IntentProgress::Immediate));
+            }
+            Fate::Live
+        })
+    });
 }
 
 use super::ClearInteractable;
 use stagemaster::RemoveInteractable;
 
-impl Recipient<ClearInteractable> for Deselecter {
-    fn receive(&mut self, _msg: &ClearInteractable) -> Fate {
-        UserInterface::id() << RemoveInteractable(Self::id());
-        Fate::Die
-    }
-}
-
 use stagemaster::Event3d;
 use super::{ChangeIntent, Intent, IntentProgress};
-
-impl Recipient<Event3d> for Deselecter {
-    fn receive(&mut self, msg: &Event3d) -> Fate {
-        match *msg {
-            Event3d::DragFinished { .. } => {
-                CurrentPlan::id() << ChangeIntent(Intent::Deselect, IntentProgress::Immediate);
-                Fate::Live
-            }
-            _ => Fate::Live,
-        }
-    }
-}
-
-pub fn setup() {
-    Deselecter::register_default();
-    Deselecter::handle::<InitInteractable>();
-    Deselecter::handle::<ClearInteractable>();
-    Deselecter::handle::<Event3d>();
-}

--- a/src/game/lanes_and_cars/planning/current_plan/draggable.rs
+++ b/src/game/lanes_and_cars/planning/current_plan/draggable.rs
@@ -1,5 +1,5 @@
-use kay::{ID, Recipient, Actor, Fate};
-use kay::swarm::{Swarm, SubActor, CreateWith};
+use kay::{ID, ActorSystem, Fate};
+use kay::swarm::{Swarm, SubActor};
 use descartes::{N, Band, Into2d, Norm};
 use stagemaster::geometry::{CPath, AnyShape};
 
@@ -25,59 +25,55 @@ impl Draggable {
 use super::InitInteractable;
 use stagemaster::{UserInterface, AddInteractable};
 
-impl Recipient<InitInteractable> for Draggable {
-    fn receive(&mut self, _msg: &InitInteractable) -> Fate {
-        UserInterface::id() <<
-        AddInteractable(self.id(),
-                        AnyShape::Band(Band::new(self.path.clone(), 5.0)),
-                        4);
-        Fate::Live
-    }
+pub fn setup(system: &mut ActorSystem) {
+    system.add(Swarm::<Draggable>::new(),
+               Swarm::<Draggable>::subactors(|mut each_draggable| {
+        let ui_id = each_draggable.world().id::<UserInterface>();
+        let cp_id = each_draggable.world().id::<CurrentPlan>();
+
+        each_draggable.on_create_with(move |_: &InitInteractable, draggable, world| {
+            world.send(ui_id,
+                       AddInteractable(draggable.id(),
+                                       AnyShape::Band(Band::new(draggable.path.clone(), 5.0)),
+                                       4));
+            Fate::Live
+        });
+
+        each_draggable.on(move |_: &ClearInteractable, draggable, world| {
+            world.send(ui_id, RemoveInteractable(draggable.id()));
+            Fate::Die
+        });
+
+        each_draggable.on(move |event, _, world| {
+            match *event {
+                Event3d::DragOngoing { from, to, .. } => {
+                    world.send(cp_id,
+                               ChangeIntent(Intent::MoveSelection(to.into_2d() - from.into_2d()),
+                                            IntentProgress::Preview));
+                }
+                Event3d::DragFinished { from, to, .. } => {
+                    let delta = to.into_2d() - from.into_2d();
+                    if delta.norm() < MAXIMIZE_DISTANCE {
+                        world.send(cp_id,
+                                   ChangeIntent(Intent::MaximizeSelection,
+                                                IntentProgress::Immediate));
+                    } else {
+                        world.send(cp_id,
+                                   ChangeIntent(Intent::MoveSelection(delta),
+                                                IntentProgress::Immediate));
+                    }
+                }
+                _ => {}
+            };
+            Fate::Live
+        })
+    }));
 }
 
 use super::ClearInteractable;
 use stagemaster::RemoveInteractable;
 
-impl Recipient<ClearInteractable> for Draggable {
-    fn receive(&mut self, _msg: &ClearInteractable) -> Fate {
-        UserInterface::id() << RemoveInteractable(self.id());
-        Fate::Die
-    }
-}
-
 use stagemaster::Event3d;
 use super::{ChangeIntent, Intent, IntentProgress};
 
 const MAXIMIZE_DISTANCE: N = 0.5;
-
-impl Recipient<Event3d> for Draggable {
-    fn receive(&mut self, msg: &Event3d) -> Fate {
-        match *msg {
-            Event3d::DragOngoing { from, to, .. } => {
-                CurrentPlan::id() <<
-                ChangeIntent(Intent::MoveSelection(to.into_2d() - from.into_2d()),
-                             IntentProgress::Preview);
-                Fate::Live
-            }
-            Event3d::DragFinished { from, to, .. } => {
-                let delta = to.into_2d() - from.into_2d();
-                if delta.norm() < MAXIMIZE_DISTANCE {
-                    CurrentPlan::id() <<
-                    ChangeIntent(Intent::MaximizeSelection, IntentProgress::Immediate);
-                } else {
-                    CurrentPlan::id() <<
-                    ChangeIntent(Intent::MoveSelection(delta), IntentProgress::Immediate);
-                }
-                Fate::Live
-            }
-            _ => Fate::Live,
-        }
-    }
-}
-
-pub fn setup() {
-    Swarm::<Draggable>::register_default();
-    Swarm::<Draggable>::handle::<CreateWith<Draggable, InitInteractable>>();
-    Swarm::<Draggable>::handle::<ClearInteractable>();
-    Swarm::<Draggable>::handle::<Event3d>();
-}

--- a/src/game/lanes_and_cars/planning/current_plan/interaction.rs
+++ b/src/game/lanes_and_cars/planning/current_plan/interaction.rs
@@ -1,4 +1,5 @@
-use kay::{Recipient, Actor, Fate};
+use kay::{ActorSystem, Fate};
+use kay::swarm::Swarm;
 use super::CurrentPlan;
 use stagemaster::geometry::AnyShape;
 use stagemaster::combo::{Bindings, Combo2};
@@ -34,170 +35,154 @@ impl Default for InteractionSettings {
 use super::InitInteractable;
 use monet::{Renderer, AddEyeListener};
 use stagemaster::{UserInterface, AddInteractable, AddInteractable2d, Focus};
+use game::lanes_and_cars::lane::Lane;
 
-impl Recipient<InitInteractable> for CurrentPlan {
-    fn receive(&mut self, _msg: &InitInteractable) -> Fate {
-        self.interaction.settings = ::ENV.load_settings("Plan Editing");
-        UserInterface::id() << AddInteractable(CurrentPlan::id(), AnyShape::Everywhere, 0);
-        UserInterface::id() << AddInteractable2d(CurrentPlan::id());
-        UserInterface::id() << Focus(CurrentPlan::id());
-        Renderer::id() <<
-        AddEyeListener {
-            scene_id: 0,
-            listener: CurrentPlan::id(),
-        };
-        Fate::Live
-    }
+pub fn setup(system: &mut ActorSystem) {
+    system.extend::<CurrentPlan, _>(|mut the_cp| {
+        let ui_id = the_cp.world().id::<UserInterface>();
+        let cp_id = the_cp.world().id::<CurrentPlan>();
+        let renderer_id = the_cp.world().id::<Renderer>();
+        let lanes_swarm_id = the_cp.world().id::<Swarm<Lane>>();
+
+        the_cp.on(move |_: &InitInteractable, plan, world| {
+            plan.interaction.settings = ::ENV.load_settings("Plan Editing");
+            world.send(ui_id, AddInteractable(cp_id, AnyShape::Everywhere, 0));
+            world.send(ui_id, AddInteractable2d(cp_id));
+            world.send(ui_id, Focus(cp_id));
+            world.send(renderer_id, AddEyeListener { scene_id: 0, listener: cp_id });
+            Fate::Live
+        });
+
+        the_cp.on(|&EyeMoved { eye, .. }, plan, _| {
+            if eye.position.z < 100.0 {
+                plan.settings.select_parallel = false;
+                plan.settings.select_opposite = false;
+            } else if eye.position.z < 130.0 {
+                plan.settings.select_parallel = true;
+                plan.settings.select_opposite = false;
+            } else {
+                plan.settings.select_parallel = true;
+                plan.settings.select_opposite = true;
+            }
+            Fate::Live
+        });
+
+        the_cp.on(move |event, plan, world| {
+            match *event {
+                Event3d::Combos(combos) => {
+                    plan.interaction
+                        .settings
+                        .bindings
+                        .do_rebinding(&combos.current);
+                    let bindings = &plan.interaction.settings.bindings;
+
+                    if bindings["Materialize Plan"].is_freshly_in(&combos) {
+                        world.send(cp_id, Materialize);
+                    }
+
+                    if bindings["Redo Step"].is_freshly_in(&combos) {
+                        world.send(cp_id, Redo);
+                    } else if bindings["Undo Step"].is_freshly_in(&combos) {
+                        world.send(cp_id, Undo);
+                    }
+
+                    if bindings["Spawn Cars"].is_freshly_in(&combos) {
+                        // TODO: this is not supposed to be here!
+                        //       *but we have only one focusable!*
+                        //       WTF?! what's wrong with your UI model?
+                        //       *I uh.. I guess I should actually write a good one*
+                        //       When will you finally?!
+                        //       *Uh.. next week maybe?*
+                        use kay::swarm::ToRandom;
+                        use descartes::P3;
+                        world.send(lanes_swarm_id,
+                                   ToRandom {
+                                       n_recipients: 5000,
+                                       message: Event3d::DragFinished {
+                                           from: P3::new(0.0, 0.0, 0.0),
+                                           from2d: P2::new(0.0, 0.0),
+                                           to: P3::new(0.0, 0.0, 0.0),
+                                           to2d: P2::new(0.0, 0.0),
+                                       },
+                                   });
+                    }
+
+                    let maybe_grid_size = if bindings["Create Large Grid"].is_freshly_in(&combos) {
+                        Some(15usize)
+                    } else if bindings["Create Small Grid"]
+                                  .is_freshly_in(&combos) {
+                        Some(10usize)
+                    } else {
+                        None
+                    };
+
+                    if let Some(grid_size) = maybe_grid_size {
+                        const GRID_SPACING: N = 1000.0;
+                        for x in 0..grid_size {
+                            world.send(cp_id,
+                                       Stroke(vec![P2::new((x as f32 + 0.5) * GRID_SPACING, 0.0),
+                                                   P2::new((x as f32 + 0.5) * GRID_SPACING,
+                                                           grid_size as f32 * GRID_SPACING)]
+                                                      .into(),
+                                              StrokeState::Finished));
+                        }
+                        for y in 0..grid_size {
+                            world.send(cp_id,
+                                       Stroke(vec![P2::new(0.0, (y as f32 + 0.5) * GRID_SPACING),
+                                                   P2::new(grid_size as f32 * GRID_SPACING,
+                                                           (y as f32 + 0.5) * GRID_SPACING)]
+                                                      .into(),
+                                              StrokeState::Finished));
+                        }
+                    }
+
+                    if bindings["Delete Selection"].is_freshly_in(&combos) {
+                        world.send(cp_id,
+                                   ChangeIntent(Intent::DeleteSelection,
+                                                IntentProgress::Immediate));
+                    }
+                }
+                Event3d::ButtonDown(NumberKey(num)) => {
+                    if num == 0 {
+                        world.send(cp_id, ToggleBothSides);
+                    } else {
+                        world.send(cp_id, SetNLanes(num as usize));
+                    }
+                }
+                _ => {}
+            };
+            Fate::Live
+        });
+
+        the_cp.on(|&DrawUI2d { ui_ptr, return_to }, plan, world| {
+            let ui = unsafe { Box::from_raw(ui_ptr as *mut ::imgui::Ui) };
+
+            ui.window(im_str!("Controls"))
+                .build(|| {
+                    ui.text(im_str!("Plan Editing"));
+                    ui.separator();
+
+                    if plan.interaction.settings.bindings.settings_ui(&ui) {
+                        ::ENV.write_settings("Plan Editing", &plan.interaction.settings)
+                    }
+
+                    ui.spacing();
+                });
+
+            world.send(return_to, Ui2dDrawn { ui_ptr: Box::into_raw(ui) as usize });
+            Fate::Live
+        });
+
+        the_cp.world().send(cp_id, InitInteractable);
+    });
 }
 
 use monet::EyeMoved;
-
-impl Recipient<EyeMoved> for CurrentPlan {
-    fn receive(&mut self, msg: &EyeMoved) -> Fate {
-        match *msg {
-            EyeMoved { eye, .. } => {
-                if eye.position.z < 100.0 {
-                    self.settings.select_parallel = false;
-                    self.settings.select_opposite = false;
-                } else if eye.position.z < 130.0 {
-                    self.settings.select_parallel = true;
-                    self.settings.select_opposite = false;
-                } else {
-                    self.settings.select_parallel = true;
-                    self.settings.select_opposite = true;
-                }
-                Fate::Live
-            }
-        }
-    }
-}
 
 use stagemaster::Event3d;
 use super::{Intent, ChangeIntent, IntentProgress, Materialize, Undo, Redo, SetNLanes,
             ToggleBothSides};
 use super::stroke_canvas::{Stroke, StrokeState};
 
-impl Recipient<Event3d> for CurrentPlan {
-    fn receive(&mut self, msg: &Event3d) -> Fate {
-        match *msg {
-            Event3d::Combos(combos) => {
-                self.interaction
-                    .settings
-                    .bindings
-                    .do_rebinding(&combos.current);
-                let bindings = &self.interaction.settings.bindings;
-
-                if bindings["Materialize Plan"].is_freshly_in(&combos) {
-                    CurrentPlan::id() << Materialize;
-                }
-
-                if bindings["Redo Step"].is_freshly_in(&combos) {
-                    CurrentPlan::id() << Redo;
-                } else if bindings["Undo Step"].is_freshly_in(&combos) {
-                    CurrentPlan::id() << Undo;
-                }
-
-                if bindings["Spawn Cars"].is_freshly_in(&combos) {
-                    // TODO: this is not supposed to be here!
-                    //       *but we have only one focusable!*
-                    //       WTF?! what's wrong with your UI model?
-                    //       *I uh.. I guess I should actually write a good one*
-                    //       When will you finally?!
-                    //       *Uh.. next week maybe?*
-                    use kay::swarm::{Swarm, ToRandom};
-                    use descartes::P3;
-                    Swarm::<::game::lanes_and_cars::lane::Lane>::all() <<
-                    ToRandom {
-                        n_recipients: 5000,
-                        message: Event3d::DragFinished {
-                            from: P3::new(0.0, 0.0, 0.0),
-                            from2d: P2::new(0.0, 0.0),
-                            to: P3::new(0.0, 0.0, 0.0),
-                            to2d: P2::new(0.0, 0.0),
-                        },
-                    };
-                }
-
-                let maybe_grid_size = if bindings["Create Large Grid"].is_freshly_in(&combos) {
-                    Some(15usize)
-                } else if bindings["Create Small Grid"]
-                              .is_freshly_in(&combos) {
-                    Some(10usize)
-                } else {
-                    None
-                };
-
-                if let Some(grid_size) = maybe_grid_size {
-                    const GRID_SPACING: N = 1000.0;
-                    for x in 0..grid_size {
-                        Self::id() <<
-                        Stroke(vec![P2::new((x as f32 + 0.5) * GRID_SPACING, 0.0),
-                                    P2::new((x as f32 + 0.5) * GRID_SPACING,
-                                            grid_size as f32 * GRID_SPACING)]
-                                       .into(),
-                               StrokeState::Finished);
-                    }
-                    for y in 0..grid_size {
-                        Self::id() <<
-                        Stroke(vec![P2::new(0.0, (y as f32 + 0.5) * GRID_SPACING),
-                                    P2::new(grid_size as f32 * GRID_SPACING,
-                                            (y as f32 + 0.5) * GRID_SPACING)]
-                                       .into(),
-                               StrokeState::Finished);
-                    }
-                }
-
-                if bindings["Delete Selection"].is_freshly_in(&combos) {
-                    Self::id() << ChangeIntent(Intent::DeleteSelection, IntentProgress::Immediate);
-                }
-
-                Fate::Live
-            }
-            Event3d::ButtonDown(NumberKey(num)) => {
-                if num == 0 {
-                    Self::id() << ToggleBothSides;
-                } else {
-                    Self::id() << SetNLanes(num as usize);
-                }
-                Fate::Live
-            }
-            _ => Fate::Live,
-        }
-    }
-}
-
 use stagemaster::DrawUI2d;
 use stagemaster::Ui2dDrawn;
-
-impl Recipient<DrawUI2d> for CurrentPlan {
-    fn receive(&mut self, msg: &DrawUI2d) -> Fate {
-        match *msg {
-            DrawUI2d { ui_ptr, return_to } => {
-                let ui = unsafe { Box::from_raw(ui_ptr as *mut ::imgui::Ui) };
-
-                ui.window(im_str!("Controls"))
-                    .build(|| {
-                        ui.text(im_str!("Plan Editing"));
-                        ui.separator();
-
-                        if self.interaction.settings.bindings.settings_ui(&ui) {
-                            ::ENV.write_settings("Plan Editing", &self.interaction.settings)
-                        }
-
-                        ui.spacing();
-                    });
-
-                return_to << Ui2dDrawn { ui_ptr: Box::into_raw(ui) as usize };
-                Fate::Live
-            }
-        }
-    }
-}
-
-pub fn setup() {
-    CurrentPlan::handle::<InitInteractable>();
-    CurrentPlan::handle::<EyeMoved>();
-    CurrentPlan::handle::<Event3d>();
-    CurrentPlan::handle::<DrawUI2d>();
-    CurrentPlan::id() << InitInteractable;
-}

--- a/src/game/lanes_and_cars/planning/current_plan/rendering.rs
+++ b/src/game/lanes_and_cars/planning/current_plan/rendering.rs
@@ -1,4 +1,4 @@
-use kay::{ID, Recipient, Fate, Actor};
+use kay::{ID, Fate, ActorSystem, World};
 use compact::CDict;
 use descartes::{N, Band, Path, FiniteCurve};
 use monet::{Thing, Instance};
@@ -8,102 +8,96 @@ use super::super::plan::{PlanDelta, BuiltStrokes, PlanResultDelta};
 use super::super::lane_stroke::LaneStroke;
 
 use monet::SetupInScene;
-
-impl Recipient<SetupInScene> for CurrentPlan {
-    fn receive(&mut self, _msg: &SetupInScene) -> Fate {
-        Fate::Live
-    }
-}
-
 use monet::RenderToScene;
 use monet::UpdateThing;
 
-impl Recipient<RenderToScene> for CurrentPlan {
-    fn receive(&mut self, msg: &RenderToScene) -> Fate {
-        match *msg {
-            RenderToScene {
-                renderer_id,
-                scene_id,
-            } => {
-                if self.preview.is_none() {
-                    let preview = self.update_preview();
-                    render_strokes(&preview.plan_delta, renderer_id, scene_id);
+pub fn setup(system: &mut ActorSystem) {
+    system.extend::<CurrentPlan, _>(|mut the_cp| {
+        the_cp.on(|_: &SetupInScene, _, _| Fate::Live);
 
-                }
-                if !self.interactables_valid {
-                    self.update_interactables();
-                }
-                if let Some(ref result_delta) = self.preview_result_delta {
-                    // TODO: add something like prepare-render to monet to make sure
-                    // we have new state in time
-                    if !self.preview_result_delta_rendered {
-                        self.preview_result_delta_rendered = true;
+        the_cp.on(|&RenderToScene { renderer_id, scene_id }, plan, world| {
+            if plan.preview.is_none() {
+                let preview = plan.update_preview(world);
+                render_strokes(&preview.plan_delta, renderer_id, scene_id, world);
 
-                        render_trimmed_strokes(result_delta, renderer_id, scene_id);
-                        render_intersections(result_delta, renderer_id, scene_id);
-                        render_transfer_lanes(result_delta, renderer_id, scene_id);
-                    }
-                }
-                if let Some(ref built_strokes) = self.built_strokes {
-                    render_selections(&self.preview.as_ref().unwrap().selections,
-                                      &self.preview.as_ref().unwrap().plan_delta,
-                                      built_strokes,
-                                      renderer_id,
-                                      scene_id);
-                }
-
-                Fate::Live
             }
-        }
-    }
+            if !plan.interactables_valid {
+                plan.update_interactables(world);
+            }
+            if let Some(ref result_delta) = plan.preview_result_delta {
+                // TODO: add something like prepare-render to monet to make sure
+                // we have new state in time
+                if !plan.preview_result_delta_rendered {
+                    plan.preview_result_delta_rendered = true;
+
+                    render_trimmed_strokes(result_delta, renderer_id, scene_id, world);
+                    render_intersections(result_delta, renderer_id, scene_id, world);
+                    render_transfer_lanes(result_delta, renderer_id, scene_id, world);
+                }
+            }
+            if let Some(ref built_strokes) = plan.built_strokes {
+                render_selections(&plan.preview.as_ref().unwrap().selections,
+                                  &plan.preview.as_ref().unwrap().plan_delta,
+                                  built_strokes,
+                                  renderer_id,
+                                  scene_id,
+                                  world);
+            }
+
+            Fate::Live
+        });
+    });
 }
 
-fn render_strokes(delta: &PlanDelta, renderer_id: ID, scene_id: usize) {
+fn render_strokes(delta: &PlanDelta, renderer_id: ID, scene_id: usize, world: &mut World) {
     let destroyed_strokes_thing: Thing = delta
         .strokes_to_destroy
         .pairs()
         .filter(|&(_, stroke)| stroke.nodes().len() > 1)
         .map(|(_, stroke)| band_to_thing(&Band::new(stroke.path().clone(), 5.0), 0.1))
         .sum();
-    renderer_id <<
-    UpdateThing {
-        scene_id: scene_id,
-        thing_id: 5496,
-        thing: destroyed_strokes_thing,
-        instance: Instance::with_color([1.0, 0.0, 0.0]),
-        is_decal: true,
-    };
+    world.send(renderer_id,
+               UpdateThing {
+                   scene_id: scene_id,
+                   thing_id: 5496,
+                   thing: destroyed_strokes_thing,
+                   instance: Instance::with_color([1.0, 0.0, 0.0]),
+                   is_decal: true,
+               });
     let stroke_base_thing: Thing = delta
         .new_strokes
         .iter()
         .filter(|stroke| stroke.nodes().len() > 1)
         .map(|stroke| band_to_thing(&Band::new(stroke.path().clone(), 6.0), 0.1))
         .sum();
-    renderer_id <<
-    UpdateThing {
-        scene_id: scene_id,
-        thing_id: 5498,
-        thing: stroke_base_thing,
-        instance: Instance::with_color([1.0, 1.0, 1.0]),
-        is_decal: true,
-    };
+    world.send(renderer_id,
+               UpdateThing {
+                   scene_id: scene_id,
+                   thing_id: 5498,
+                   thing: stroke_base_thing,
+                   instance: Instance::with_color([1.0, 1.0, 1.0]),
+                   is_decal: true,
+               });
     let stroke_thing: Thing = delta
         .new_strokes
         .iter()
         .filter(|stroke| stroke.nodes().len() > 1)
         .map(LaneStroke::preview_thing)
         .sum();
-    renderer_id <<
-    UpdateThing {
-        scene_id: scene_id,
-        thing_id: 5499,
-        thing: stroke_thing,
-        instance: Instance::with_color([0.6, 0.6, 0.6]),
-        is_decal: true,
-    };
+    world.send(renderer_id,
+               UpdateThing {
+                   scene_id: scene_id,
+                   thing_id: 5499,
+                   thing: stroke_thing,
+                   instance: Instance::with_color([0.6, 0.6, 0.6]),
+                   is_decal: true,
+               });
 }
 
-fn render_trimmed_strokes(result_delta: &PlanResultDelta, renderer_id: ID, scene_id: usize) {
+fn render_trimmed_strokes(result_delta: &PlanResultDelta,
+                          renderer_id: ID,
+                          scene_id: usize,
+                          world: &mut World) {
     let trimmed_stroke_thing: Thing = result_delta
         .trimmed_strokes
         .to_create
@@ -111,17 +105,20 @@ fn render_trimmed_strokes(result_delta: &PlanResultDelta, renderer_id: ID, scene
         .filter(|stroke| stroke.nodes().len() > 1)
         .map(LaneStroke::preview_thing)
         .sum();
-    renderer_id <<
-    UpdateThing {
-        scene_id: scene_id,
-        thing_id: 5500,
-        thing: trimmed_stroke_thing,
-        instance: Instance::with_color([0.3, 0.3, 0.5]),
-        is_decal: true,
-    };
+    world.send(renderer_id,
+               UpdateThing {
+                   scene_id: scene_id,
+                   thing_id: 5500,
+                   thing: trimmed_stroke_thing,
+                   instance: Instance::with_color([0.3, 0.3, 0.5]),
+                   is_decal: true,
+               });
 }
 
-fn render_intersections(result_delta: &PlanResultDelta, renderer_id: ID, scene_id: usize) {
+fn render_intersections(result_delta: &PlanResultDelta,
+                        renderer_id: ID,
+                        scene_id: usize,
+                        world: &mut World) {
     let intersections_thing: Thing = result_delta
         .intersections
         .to_create
@@ -129,14 +126,14 @@ fn render_intersections(result_delta: &PlanResultDelta, renderer_id: ID, scene_i
         .filter(|i| !i.shape.segments().is_empty())
         .map(|i| band_to_thing(&Band::new(i.shape.clone(), 0.4), 0.5))
         .sum();
-    renderer_id <<
-    UpdateThing {
-        scene_id: scene_id,
-        thing_id: 5501,
-        thing: intersections_thing,
-        instance: Instance::with_color([0.0, 0.0, 1.0]),
-        is_decal: true,
-    };
+    world.send(renderer_id,
+               UpdateThing {
+                   scene_id: scene_id,
+                   thing_id: 5501,
+                   thing: intersections_thing,
+                   instance: Instance::with_color([0.0, 0.0, 1.0]),
+                   is_decal: true,
+               });
     let connecting_strokes_thing: Thing = result_delta
         .intersections
         .to_create
@@ -144,79 +141,82 @@ fn render_intersections(result_delta: &PlanResultDelta, renderer_id: ID, scene_i
         .filter(|i| !i.strokes.is_empty())
         .map(|i| -> Thing { i.strokes.iter().map(LaneStroke::preview_thing).sum() })
         .sum();
-    renderer_id <<
-    UpdateThing {
-        scene_id: scene_id,
-        thing_id: 5502,
-        thing: connecting_strokes_thing,
-        instance: Instance::with_color([0.5, 0.5, 1.0]),
-        is_decal: true,
-    };
+    world.send(renderer_id,
+               UpdateThing {
+                   scene_id: scene_id,
+                   thing_id: 5502,
+                   thing: connecting_strokes_thing,
+                   instance: Instance::with_color([0.5, 0.5, 1.0]),
+                   is_decal: true,
+               });
 }
 
-fn render_transfer_lanes(result_delta: &PlanResultDelta, renderer_id: ID, scene_id: usize) {
+fn render_transfer_lanes(result_delta: &PlanResultDelta,
+                         renderer_id: ID,
+                         scene_id: usize,
+                         world: &mut World) {
     let transfer_strokes_thing: Thing = result_delta
         .transfer_strokes
         .to_create
         .values()
         .map(|lane_stroke| band_to_thing(&Band::new(lane_stroke.path().clone(), 0.3), 0.1))
         .sum();
-    renderer_id <<
-    UpdateThing {
-        scene_id: scene_id,
-        thing_id: 5503,
-        thing: transfer_strokes_thing,
-        instance: Instance::with_color([1.0, 0.5, 0.0]),
-        is_decal: true,
-    };
+    world.send(renderer_id,
+               UpdateThing {
+                   scene_id: scene_id,
+                   thing_id: 5503,
+                   thing: transfer_strokes_thing,
+                   instance: Instance::with_color([1.0, 0.5, 0.0]),
+                   is_decal: true,
+               });
 }
 
 fn render_selections(selections: &CDict<SelectableStrokeRef, (N, N)>,
                      plan_delta: &PlanDelta,
                      built_strokes: &BuiltStrokes,
                      renderer_id: ID,
-                     scene_id: usize) {
-    let addable_thing =
-        selections
-            .pairs()
-            .filter_map(|(&selection_ref, &(start, end))| {
-                            let stroke = selection_ref.get_stroke(plan_delta, built_strokes);
-                            stroke.path().subsection(start, end).and_then(|subsection| {
-                subsection.shift_orthogonally(5.0).map(|shifted_subsection| {
-                    band_to_thing(&Band::new(shifted_subsection, 5.0), 0.1)
-                })
-            })
+                     scene_id: usize,
+                     world: &mut World) {
+    let addable_thing = selections
+        .pairs()
+        .filter_map(|(&selection_ref, &(start, end))| {
+            let stroke = selection_ref.get_stroke(plan_delta, built_strokes);
+            stroke
+                .path()
+                .subsection(start, end)
+                .and_then(|subsection| {
+                    subsection
+                        .shift_orthogonally(5.0)
+                        .map(|shifted_subsection| {
+                            band_to_thing(&Band::new(shifted_subsection, 5.0), 0.1)
                         })
-            .sum();
-    renderer_id <<
-    UpdateThing {
-        scene_id: scene_id,
-        thing_id: 5497,
-        thing: addable_thing,
-        instance: Instance::with_color([0.8, 0.8, 1.0]),
-        is_decal: true,
-    };
+                })
+        })
+        .sum();
+    world.send(renderer_id,
+               UpdateThing {
+                   scene_id: scene_id,
+                   thing_id: 5497,
+                   thing: addable_thing,
+                   instance: Instance::with_color([0.8, 0.8, 1.0]),
+                   is_decal: true,
+               });
     let selection_thing = selections
         .pairs()
         .filter_map(|(&selection_ref, &(start, end))| {
-                        let stroke = selection_ref.get_stroke(plan_delta, built_strokes);
-                        stroke
-                            .path()
-                            .subsection(start, end)
-                            .map(|subsection| band_to_thing(&Band::new(subsection, 5.0), 0.1))
-                    })
+            let stroke = selection_ref.get_stroke(plan_delta, built_strokes);
+            stroke
+                .path()
+                .subsection(start, end)
+                .map(|subsection| band_to_thing(&Band::new(subsection, 5.0), 0.1))
+        })
         .sum();
-    renderer_id <<
-    UpdateThing {
-        scene_id: scene_id,
-        thing_id: 5504,
-        thing: selection_thing,
-        instance: Instance::with_color([0.0, 0.0, 1.0]),
-        is_decal: true,
-    };
-}
-
-pub fn setup() {
-    CurrentPlan::handle::<SetupInScene>();
-    CurrentPlan::handle::<RenderToScene>();
+    world.send(renderer_id,
+               UpdateThing {
+                   scene_id: scene_id,
+                   thing_id: 5504,
+                   thing: selection_thing,
+                   instance: Instance::with_color([0.0, 0.0, 1.0]),
+                   is_decal: true,
+               });
 }

--- a/src/game/lanes_and_cars/planning/mod.rs
+++ b/src/game/lanes_and_cars/planning/mod.rs
@@ -1,8 +1,10 @@
+use kay::ActorSystem;
+
 pub mod plan;
 pub mod lane_stroke;
 pub mod plan_result_steps;
 pub mod current_plan;
 
-pub fn setup() {
-    current_plan::setup();
+pub fn setup(system: &mut ActorSystem) {
+    current_plan::setup(system);
 }

--- a/src/game/lanes_and_cars/planning/plan.rs
+++ b/src/game/lanes_and_cars/planning/plan.rs
@@ -49,33 +49,31 @@ impl<'a> RoughlyComparable for &'a Intersection {
         self.incoming
             .values()
             .all(|self_incoming| {
-                     other
-                         .incoming
-                         .values()
-                         .any(|other_incoming| {
-                                  self_incoming.is_roughly_within(other_incoming, tolerance)
-                              })
-                 }) && self.outgoing.len() == other.outgoing.len() &&
+                other
+                    .incoming
+                    .values()
+                    .any(|other_incoming| {
+                        self_incoming.is_roughly_within(other_incoming, tolerance)
+                    })
+            }) && self.outgoing.len() == other.outgoing.len() &&
         self.outgoing
             .values()
             .all(|self_outgoing| {
-                     other
-                         .outgoing
-                         .values()
-                         .any(|other_outgoing| {
-                                  self_outgoing.is_roughly_within(other_outgoing, tolerance)
-                              })
-                 }) && self.strokes.len() == other.strokes.len() &&
+                other
+                    .outgoing
+                    .values()
+                    .any(|other_outgoing| {
+                        self_outgoing.is_roughly_within(other_outgoing, tolerance)
+                    })
+            }) && self.strokes.len() == other.strokes.len() &&
         self.strokes
             .iter()
             .all(|self_stroke| {
-                     other
-                         .strokes
-                         .iter()
-                         .any(|other_stroke| {
-                                  self_stroke.is_roughly_within(other_stroke, tolerance)
-                              })
-                 })
+                other
+                    .strokes
+                    .iter()
+                    .any(|other_stroke| self_stroke.is_roughly_within(other_stroke, tolerance))
+            })
     }
 }
 

--- a/src/game/lanes_and_cars/rendering/lane_thing_collector.rs
+++ b/src/game/lanes_and_cars/rendering/lane_thing_collector.rs
@@ -1,6 +1,6 @@
 use monet::{Thing, Instance};
 use compact::CDict;
-use kay::{ID, Actor, Recipient, Fate};
+use kay::{ID, ActorSystem, Fate};
 use std::marker::PhantomData;
 use itertools::Itertools;
 
@@ -24,14 +24,144 @@ pub struct ThingCollector<T: Clone> {
     _marker: PhantomData<*const T>,
 }
 
-impl<T: 'static + Clone> Actor for ThingCollector<T> {}
 
 use monet::SetupInScene;
 
-impl<T: Clone> Recipient<SetupInScene> for ThingCollector<T> {
-    fn receive(&mut self, _msg: &SetupInScene) -> Fate {
-        Fate::Live
-    }
+pub fn setup<T: Clone + 'static>(system: &mut ActorSystem,
+                                 instance_color: [f32; 3],
+                                 base_thing_id: u16,
+                                 is_decal: bool) {
+    let initial = ThingCollector::<T> {
+        instance_color: instance_color,
+        base_thing_id: base_thing_id,
+        is_decal: is_decal,
+        living_things: CDict::new(),
+        frozen_things: CDict::new(),
+        n_frozen_groups: 0,
+        cached_frozen_things_dirty: false,
+        n_total_groups: 0,
+        _marker: PhantomData,
+    };
+
+    system.add(initial, |mut the_collector| {
+        let collector_id = the_collector.world().id::<ThingCollector<T>>();
+
+        the_collector.on(|_: &SetupInScene, _, _| Fate::Live);
+
+        the_collector.on(|control, coll, _| {
+            match *control {
+                Control::Update(id, ref thing) => {
+                    if coll.frozen_things.get(id).is_none() {
+                        coll.living_things.insert(id, thing.clone());
+                    }
+                }
+                Control::Freeze(id) => {
+                    if let Some(thing) = coll.living_things.remove(id) {
+                        coll.frozen_things.insert(id, thing);
+                        coll.cached_frozen_things_dirty = true;
+                    }
+                }
+                Control::Unfreeze(id) => {
+                    if let Some(thing) = coll.frozen_things.remove(id) {
+                        coll.living_things.insert(id, thing);
+                        coll.cached_frozen_things_dirty = true;
+                    }
+                }
+                Control::Remove(id) => {
+                    coll.living_things.remove(id);
+                    if coll.frozen_things.remove(id).is_some() {
+                        coll.cached_frozen_things_dirty = true;
+                    };
+                }
+            };
+            Fate::Live
+        });
+
+        the_collector.on(move |&RenderToScene { renderer_id, scene_id }, coll, world| {
+            // TODO: this introduces 1 frame delay
+            for id in coll.living_things.keys() {
+                world.send(*id, RenderToCollector(collector_id));
+            }
+
+            if coll.cached_frozen_things_dirty {
+                let cached_frozen_things_grouped = coll.frozen_things
+                    .values()
+                    .cloned()
+                    .coalesce(|a, b| if a.vertices.len() + b.vertices.len() >
+                                        u16::max_value() as usize {
+                                  Err((a, b))
+                              } else {
+                                  Ok(a + b)
+                              });
+                coll.cached_frozen_things_dirty = false;
+
+                coll.n_frozen_groups = 0;
+
+                for frozen_group in cached_frozen_things_grouped {
+                    world.send(renderer_id,
+                               UpdateThing {
+                                   scene_id: scene_id,
+                                   thing_id: coll.base_thing_id + coll.n_frozen_groups as u16,
+                                   thing: frozen_group,
+                                   instance: Instance {
+                                       instance_position: [0.0, 0.0, -0.1],
+                                       instance_direction: [1.0, 0.0],
+                                       instance_color: coll.instance_color,
+                                   },
+                                   is_decal: coll.is_decal,
+                               });
+
+                    coll.n_frozen_groups += 1;
+                }
+            }
+
+            let living_thing_groups = coll.living_things
+                .values()
+                .cloned()
+                .coalesce(|a, b| if a.vertices.len() + b.vertices.len() >
+                                    u16::max_value() as usize {
+                              Err((a, b))
+                          } else {
+                              Ok(a + b)
+                          });
+
+            let mut new_n_total_groups = coll.n_frozen_groups;
+
+            for living_thing_group in living_thing_groups {
+                world.send(renderer_id,
+                           UpdateThing {
+                               scene_id: scene_id,
+                               thing_id: coll.base_thing_id + new_n_total_groups as u16,
+                               thing: living_thing_group,
+                               instance: Instance {
+                                   instance_position: [0.0, 0.0, -0.1],
+                                   instance_direction: [1.0, 0.0],
+                                   instance_color: coll.instance_color,
+                               },
+                               is_decal: coll.is_decal,
+                           });
+
+                new_n_total_groups += 1;
+            }
+
+            if new_n_total_groups > coll.n_total_groups {
+                for thing_to_empty_id in new_n_total_groups..coll.n_total_groups {
+                    world.send(renderer_id,
+                               UpdateThing {
+                                   scene_id: scene_id,
+                                   thing_id: coll.base_thing_id + thing_to_empty_id as u16,
+                                   thing: Thing::new(vec![], vec![]),
+                                   instance: Instance::with_color([0.0, 0.0, 0.0]),
+                                   is_decal: coll.is_decal,
+                               })
+                }
+            }
+
+            coll.n_total_groups = new_n_total_groups;
+
+            Fate::Live
+        })
+    });
 }
 
 #[derive(Compact, Clone)]
@@ -42,156 +172,9 @@ pub enum Control {
     Remove(ID),
 }
 
-impl<T: Clone> Recipient<Control> for ThingCollector<T> {
-    fn receive(&mut self, msg: &Control) -> Fate {
-        match *msg {
-            Control::Update(id, ref thing) => {
-                match self.frozen_things.get(id) {
-                    Some(_) => Fate::Live,
-                    None => {
-                        self.living_things.insert(id, thing.clone());
-                        Fate::Live
-                    }
-                }
-            }
-            Control::Freeze(id) => {
-                if let Some(thing) = self.living_things.remove(id) {
-                    self.frozen_things.insert(id, thing);
-                    self.cached_frozen_things_dirty = true;
-                }
-                Fate::Live
-            }
-            Control::Unfreeze(id) => {
-                if let Some(thing) = self.frozen_things.remove(id) {
-                    self.living_things.insert(id, thing);
-                    self.cached_frozen_things_dirty = true;
-                }
-                Fate::Live
-            }
-            Control::Remove(id) => {
-                self.living_things.remove(id);
-                if self.frozen_things.remove(id).is_some() {
-                    self.cached_frozen_things_dirty = true;
-                };
-                Fate::Live
-            }
-        }
-    }
-}
 
 use monet::RenderToScene;
 use monet::UpdateThing;
 
 #[derive(Copy, Clone)]
 pub struct RenderToCollector(pub ID);
-
-impl<T: Clone + 'static> Recipient<RenderToScene> for ThingCollector<T> {
-    fn receive(&mut self, msg: &RenderToScene) -> Fate {
-        match *msg {
-            RenderToScene {
-                renderer_id,
-                scene_id,
-            } => {
-                // TODO: this introduces 1 frame delay
-                for id in self.living_things.keys() {
-                    *id << RenderToCollector(Self::id());
-                }
-
-                if self.cached_frozen_things_dirty {
-                    let cached_frozen_things_grouped = self.frozen_things
-                        .values()
-                        .cloned()
-                        .coalesce(|a, b| if a.vertices.len() + b.vertices.len() >
-                                            u16::max_value() as usize {
-                                      Err((a, b))
-                                  } else {
-                                      Ok(a + b)
-                                  });
-                    self.cached_frozen_things_dirty = false;
-
-                    self.n_frozen_groups = 0;
-
-                    for frozen_group in cached_frozen_things_grouped {
-                        renderer_id <<
-                        UpdateThing {
-                            scene_id: scene_id,
-                            thing_id: self.base_thing_id + self.n_frozen_groups as u16,
-                            thing: frozen_group,
-                            instance: Instance {
-                                instance_position: [0.0, 0.0, -0.1],
-                                instance_direction: [1.0, 0.0],
-                                instance_color: self.instance_color,
-                            },
-                            is_decal: self.is_decal,
-                        };
-
-                        self.n_frozen_groups += 1;
-                    }
-                }
-
-                let living_thing_groups = self.living_things
-                    .values()
-                    .cloned()
-                    .coalesce(|a, b| if a.vertices.len() + b.vertices.len() >
-                                        u16::max_value() as usize {
-                                  Err((a, b))
-                              } else {
-                                  Ok(a + b)
-                              });
-
-                let mut new_n_total_groups = self.n_frozen_groups;
-
-                for living_thing_group in living_thing_groups {
-                    renderer_id <<
-                    UpdateThing {
-                        scene_id: scene_id,
-                        thing_id: self.base_thing_id + new_n_total_groups as u16,
-                        thing: living_thing_group,
-                        instance: Instance {
-                            instance_position: [0.0, 0.0, -0.1],
-                            instance_direction: [1.0, 0.0],
-                            instance_color: self.instance_color,
-                        },
-                        is_decal: self.is_decal,
-                    };
-
-                    new_n_total_groups += 1;
-                }
-
-                if new_n_total_groups > self.n_total_groups {
-                    for thing_to_empty_id in new_n_total_groups..self.n_total_groups {
-                        renderer_id <<
-                        UpdateThing {
-                            scene_id: scene_id,
-                            thing_id: self.base_thing_id + thing_to_empty_id as u16,
-                            thing: Thing::new(vec![], vec![]),
-                            instance: Instance::with_color([0.0, 0.0, 0.0]),
-                            is_decal: self.is_decal,
-                        }
-                    }
-                }
-
-                self.n_total_groups = new_n_total_groups;
-
-                Fate::Live
-            }
-        }
-    }
-}
-
-pub fn setup<T: Clone + 'static>(instance_color: [f32; 3], base_thing_id: u16, is_decal: bool) {
-    ThingCollector::register_with_state(ThingCollector::<T> {
-                                            instance_color: instance_color,
-                                            base_thing_id: base_thing_id,
-                                            is_decal: is_decal,
-                                            living_things: CDict::new(),
-                                            frozen_things: CDict::new(),
-                                            n_frozen_groups: 0,
-                                            cached_frozen_things_dirty: false,
-                                            n_total_groups: 0,
-                                            _marker: PhantomData,
-                                        });
-    ThingCollector::<T>::handle::<Control>();
-    ThingCollector::<T>::handle::<SetupInScene>();
-    ThingCollector::<T>::handle::<RenderToScene>();
-}

--- a/src/game/lanes_and_cars/rendering/mod.rs
+++ b/src/game/lanes_and_cars/rendering/mod.rs
@@ -1,7 +1,7 @@
 use descartes::{Band, FiniteCurve, WithUniqueOrthogonal, Norm, Path, Dot, RoughlyComparable};
 use compact::CVec;
-use kay::{Actor, Recipient, Fate};
-use kay::swarm::{Swarm, SubActor, RecipientAsSwarm};
+use kay::{ActorSystem, Fate, World};
+use kay::swarm::{Swarm, SubActor};
 use monet::{Instance, Thing, Vertex, UpdateThing};
 use stagemaster::geometry::{band_to_thing, dash_path};
 use super::lane::{Lane, TransferLane};
@@ -20,166 +20,529 @@ use self::lane_thing_collector::ThingCollector;
 use monet::SetupInScene;
 use monet::AddBatch;
 
-impl RecipientAsSwarm<SetupInScene> for Lane {
-    fn receive(_swarm: &mut Swarm<Self>, msg: &SetupInScene) -> Fate {
-        match *msg {
-            SetupInScene {
-                renderer_id,
-                scene_id,
-            } => {
-                renderer_id <<
-                AddBatch {
-                    scene_id: scene_id,
-                    batch_id: 8000,
-                    thing: car::create(),
-                };
-                renderer_id <<
-                AddBatch {
-                    scene_id: scene_id,
-                    batch_id: 8001,
-                    thing: traffic_light::create(),
-                };
-                renderer_id <<
-                AddBatch {
-                    scene_id: scene_id,
-                    batch_id: 8002,
-                    thing: traffic_light::create_light(),
-                };
-                renderer_id <<
-                AddBatch {
-                    scene_id: scene_id,
-                    batch_id: 8003,
-                    thing: traffic_light::create_light_left(),
-                };
-                renderer_id <<
-                AddBatch {
-                    scene_id: scene_id,
-                    batch_id: 8004,
-                    thing: traffic_light::create_light_right(),
-                };
+pub fn setup(system: &mut ActorSystem) {
 
-                renderer_id <<
-                AddBatch {
-                    scene_id: scene_id,
-                    batch_id: 1333,
-                    thing: Thing::new(vec![Vertex { position: [-1.0, -1.0, 0.0] },
-                                           Vertex { position: [1.0, -1.0, 0.0] },
-                                           Vertex { position: [1.0, 1.0, 0.0] },
-                                           Vertex { position: [-1.0, 1.0, 0.0] }],
-                                      vec![0, 1, 2, 2, 3, 0]),
-                };
+    system.extend::<Swarm<Lane>, _>(|mut the_lane_swarm| {
+        the_lane_swarm.on(|&SetupInScene { renderer_id, scene_id }, _, world| {
+            world.send(renderer_id,
+                       AddBatch {
+                           scene_id: scene_id,
+                           batch_id: 8000,
+                           thing: car::create(),
+                       });
+            world.send(renderer_id,
+                       AddBatch {
+                           scene_id: scene_id,
+                           batch_id: 8001,
+                           thing: traffic_light::create(),
+                       });
+            world.send(renderer_id,
+                       AddBatch {
+                           scene_id: scene_id,
+                           batch_id: 8002,
+                           thing: traffic_light::create_light(),
+                       });
+            world.send(renderer_id,
+                       AddBatch {
+                           scene_id: scene_id,
+                           batch_id: 8003,
+                           thing: traffic_light::create_light_left(),
+                       });
+            world.send(renderer_id,
+                       AddBatch {
+                           scene_id: scene_id,
+                           batch_id: 8004,
+                           thing: traffic_light::create_light_right(),
+                       });
 
-                Fate::Live
+            world.send(renderer_id,
+                       AddBatch {
+                           scene_id: scene_id,
+                           batch_id: 1333,
+                           thing: Thing::new(vec![Vertex { position: [-1.0, -1.0, 0.0] },
+                                                  Vertex { position: [1.0, -1.0, 0.0] },
+                                                  Vertex { position: [1.0, 1.0, 0.0] },
+                                                  Vertex { position: [-1.0, 1.0, 0.0] }],
+                                             vec![0, 1, 2, 2, 3, 0]),
+                       });
+
+            Fate::Live
+        });
+    });
+
+    system.extend(Swarm::<Lane>::subactors(|mut each_lane| {
+        each_lane.on(|&RenderToCollector(collector_id), lane, world| {
+            let maybe_path = if lane.construction.progress - CONSTRUCTION_ANIMATION_DELAY <
+                                lane.construction.length {
+                lane.construction
+                    .path
+                    .subsection(0.0,
+                                (lane.construction.progress - CONSTRUCTION_ANIMATION_DELAY)
+                                    .max(0.0))
+            } else {
+                Some(lane.construction.path.clone())
+            };
+            if collector_id == world.id::<ThingCollector<LaneAsphalt>>() {
+                world.send(collector_id,
+                           Update(lane.id(),
+                                  maybe_path
+                                      .map(|path| {
+                    band_to_thing(&Band::new(path, 6.0),
+                                  if lane.connectivity.on_intersection {
+                                      0.2
+                                  } else {
+                                      0.0
+                                  })
+                })
+                                      .unwrap_or_else(|| Thing::new(vec![], vec![]))));
+                if lane.construction.progress - CONSTRUCTION_ANIMATION_DELAY >
+                   lane.construction.length {
+                    world.send(collector_id, Freeze(lane.id()))
+                }
+            } else {
+                let left_marker = maybe_path
+                    .clone()
+                    .and_then(|path| path.shift_orthogonally(2.5))
+                    .map(|path| band_to_thing(&Band::new(path, 0.6), 0.1))
+                    .unwrap_or_else(|| Thing::new(vec![], vec![]));
+
+                let right_marker = maybe_path
+                    .and_then(|path| path.shift_orthogonally(-2.5))
+                    .map(|path| band_to_thing(&Band::new(path, 0.6), 0.1))
+                    .unwrap_or_else(|| Thing::new(vec![], vec![]));
+                world.send(collector_id, Update(lane.id(), left_marker + right_marker));
+                if lane.construction.progress - CONSTRUCTION_ANIMATION_DELAY >
+                   lane.construction.length {
+                    world.send(collector_id, Freeze(lane.id()))
+                }
             }
-        }
-    }
-}
 
-impl RecipientAsSwarm<SetupInScene> for TransferLane {
-    fn receive(_swarm: &mut Swarm<Self>, msg: &SetupInScene) -> Fate {
-        match *msg {
-            SetupInScene { .. } => Fate::Live,
-        }
-    }
+            Fate::Live
+        });
+
+        each_lane.on(|&RenderToScene { renderer_id, scene_id }, lane, world| {
+            let mut cars_iter = lane.microtraffic.cars.iter();
+            let mut current_offset = 0.0;
+            let mut car_instances = CVec::with_capacity(lane.microtraffic.cars.len());
+            for segment in lane.construction.path.segments().iter() {
+                for car in cars_iter.take_while_ref(|car| {
+                    *car.position - current_offset < segment.length()
+                }) {
+                    let position2d = segment.along(*car.position - current_offset);
+                    let direction = segment.direction_along(*car.position - current_offset);
+                    car_instances.push(Instance {
+                                           instance_position: [position2d.x, position2d.y, 0.0],
+                                           instance_direction: [direction.x, direction.y],
+                                           instance_color: if DEBUG_VIEW_LANDMARKS {
+                                               ::core::colors::RANDOM_COLORS
+                                                   [car.destination.landmark.sub_actor_id as usize %
+                                               ::core::colors::RANDOM_COLORS.len()]
+                                           } else {
+                                               ::core::colors::RANDOM_COLORS
+                                                   [car.trip.sub_actor_id as usize %
+                                               ::core::colors::RANDOM_COLORS.len()]
+                                           },
+                                       })
+                }
+                current_offset += segment.length;
+            }
+
+            if DEBUG_VIEW_OBSTACLES {
+                for &(obstacle, _id) in &lane.microtraffic.obstacles {
+                    let position2d = if *obstacle.position < lane.construction.length {
+                        lane.construction.path.along(*obstacle.position)
+                    } else {
+                        lane.construction.path.end() +
+                        (*obstacle.position - lane.construction.length) *
+                        lane.construction.path.end_direction()
+                    };
+                    let direction = lane.construction
+                        .path
+                        .direction_along(*obstacle.position);
+
+                    car_instances.push(Instance {
+                                           instance_position: [position2d.x, position2d.y, 0.0],
+                                           instance_direction: [direction.x, direction.y],
+                                           instance_color: [1.0, 0.0, 0.0],
+                                       });
+                }
+            }
+
+            if !car_instances.is_empty() {
+                world.send(renderer_id,
+                           AddSeveralInstances {
+                               scene_id: scene_id,
+                               batch_id: 8000,
+                               instances: car_instances,
+                           });
+            }
+            // no traffic light for u-turn
+            if lane.connectivity.on_intersection &&
+               !lane.construction
+                    .path
+                    .end_direction()
+                    .is_roughly_within(-lane.construction.path.start_direction(), 0.1) {
+                let mut position = lane.construction.path.start();
+                let (position_shift, batch_id) = if
+                    !lane.construction
+                         .path
+                         .start_direction()
+                         .is_roughly_within(lane.construction.path.end_direction(), 0.5) {
+                    let dot = lane.construction
+                        .path
+                        .end_direction()
+                        .dot(&lane.construction.path.start_direction().orthogonal());
+                    let shift = if dot > 0.0 { 1.0 } else { -1.0 };
+                    let batch_id = if dot > 0.0 { 8004 } else { 8003 };
+                    (shift, batch_id)
+                } else {
+                    (0.0, 8002)
+                };
+                position += lane.construction.path.start_direction().orthogonal() * position_shift;
+                let direction = lane.construction.path.start_direction();
+
+                world.send(renderer_id,
+                           AddInstance {
+                               scene_id: scene_id,
+                               batch_id: 8001,
+                               instance: Instance {
+                                   instance_position: [position.x, position.y, 6.0],
+                                   instance_direction: [direction.x, direction.y],
+                                   instance_color: [0.1, 0.1, 0.1],
+                               },
+                           });
+
+                if lane.microtraffic.yellow_to_red && lane.microtraffic.green {
+                    world.send(renderer_id,
+                               AddInstance {
+                                   scene_id: scene_id,
+                                   batch_id: batch_id,
+                                   instance: Instance {
+                                       instance_position: [position.x, position.y, 6.7],
+                                       instance_direction: [direction.x, direction.y],
+                                       instance_color: [1.0, 0.8, 0.0],
+                                   },
+                               })
+                } else if lane.microtraffic.green {
+                    world.send(renderer_id,
+                               AddInstance {
+                                   scene_id: scene_id,
+                                   batch_id: batch_id,
+                                   instance: Instance {
+                                       instance_position: [position.x, position.y, 6.1],
+                                       instance_direction: [direction.x, direction.y],
+                                       instance_color: [0.0, 1.0, 0.2],
+                                   },
+                               })
+                }
+
+                if !lane.microtraffic.green {
+                    world.send(renderer_id,
+                               AddInstance {
+                                   scene_id: scene_id,
+                                   batch_id: batch_id,
+                                   instance: Instance {
+                                       instance_position: [position.x, position.y, 7.3],
+                                       instance_direction: [direction.x, direction.y],
+                                       instance_color: [1.0, 0.0, 0.0],
+                                   },
+                               });
+
+                    if lane.microtraffic.yellow_to_green {
+                        world.send(renderer_id,
+                                   AddInstance {
+                                       scene_id: scene_id,
+                                       batch_id: batch_id,
+                                       instance: Instance {
+                                           instance_position: [position.x, position.y, 6.7],
+                                           instance_direction: [direction.x, direction.y],
+                                           instance_color: [1.0, 0.8, 0.0],
+                                       },
+                                   })
+                    }
+                }
+            }
+
+            if DEBUG_VIEW_SIGNALS && lane.connectivity.on_intersection {
+                world.send(renderer_id,
+                           UpdateThing {
+                               scene_id: scene_id,
+                               thing_id: 4000 + lane.id().sub_actor_id as u16,
+                               thing: band_to_thing(&Band::new(lane.construction.path.clone(),
+                                                               0.3),
+                                                    if lane.microtraffic.green {
+                                                        0.4
+                                                    } else {
+                                                        0.2
+                                                    }),
+                               instance: Instance::with_color(if lane.microtraffic.green {
+                                                                  [0.0, 1.0, 0.0]
+                                                              } else {
+                                                                  [1.0, 0.0, 0.0]
+                                                              }),
+                               is_decal: true,
+                           });
+            }
+
+            if !lane.connectivity
+                    .interactions
+                    .iter()
+                    .any(|inter| match inter.kind {
+                             InteractionKind::Next { .. } => true,
+                             _ => false,
+                         }) {
+                world.send(renderer_id,
+                           AddInstance {
+                               scene_id: scene_id,
+                               batch_id: 1333,
+                               instance: Instance {
+                                   instance_position: [lane.construction.path.end().x,
+                                                       lane.construction.path.end().y,
+                                                       0.5],
+                                   instance_direction: [1.0, 0.0],
+                                   instance_color: [1.0, 0.0, 0.0],
+                               },
+                           });
+            }
+
+            if !lane.connectivity
+                    .interactions
+                    .iter()
+                    .any(|inter| match inter.kind {
+                             InteractionKind::Previous { .. } => true,
+                             _ => false,
+                         }) {
+                world.send(renderer_id,
+                           AddInstance {
+                               scene_id: scene_id,
+                               batch_id: 1333,
+                               instance: Instance {
+                                   instance_position: [lane.construction.path.start().x,
+                                                       lane.construction.path.start().y,
+                                                       0.5],
+                                   instance_direction: [1.0, 0.0],
+                                   instance_color: [0.0, 1.0, 0.0],
+                               },
+                           });
+            }
+
+            if DEBUG_VIEW_LANDMARKS && lane.pathfinding.routes_changed {
+                let (random_color, is_landmark) = if let Some(as_destination) =
+                    lane.pathfinding.as_destination {
+                    let random_color: [f32; 3] = ::core::colors::RANDOM_COLORS
+                        [as_destination.landmark.sub_actor_id as usize %
+                    ::core::colors::RANDOM_COLORS.len()];
+                    let weaker_random_color = [(random_color[0] + 1.0) / 2.0,
+                                               (random_color[1] + 1.0) / 2.0,
+                                               (random_color[2] + 1.0) / 2.0];
+                    (weaker_random_color, as_destination.is_landmark())
+                } else {
+                    ([1.0, 1.0, 1.0], false)
+                };
+
+                world.send(renderer_id,
+                           UpdateThing {
+                               scene_id: scene_id,
+                               thing_id: 4000 + lane.id().sub_actor_id as u16,
+                               thing: band_to_thing(&Band::new(lane.construction.path.clone(),
+                                                               if is_landmark {
+                                                                   2.5
+                                                               } else {
+                                                                   1.0
+                                                               }),
+                                                    0.4),
+                               instance: Instance::with_color(random_color),
+                               is_decal: true,
+                           });
+            }
+            Fate::Live
+        })
+    }));
+
+    system.extend::<Swarm<TransferLane>, _>(|mut the_t_lane_swarm| {
+        the_t_lane_swarm.on(|_: &SetupInScene, _, _| Fate::Live)
+    });
+
+    system.extend(Swarm::<TransferLane>::subactors(|mut each_t_lane| {
+        each_t_lane.on(|&RenderToCollector(collector_id), lane, world| {
+            let maybe_path = if lane.construction.progress - 2.0 * CONSTRUCTION_ANIMATION_DELAY <
+                                lane.construction.length {
+                lane.construction
+                    .path
+                    .subsection(0.0,
+                                (lane.construction.progress - 2.0 * CONSTRUCTION_ANIMATION_DELAY)
+                                    .max(0.0))
+            } else {
+                Some(lane.construction.path.clone())
+            };
+
+            world.send(collector_id,
+                       Update(lane.id(),
+                              maybe_path
+                                  .map(|path| {
+                dash_path(&path, 2.0, 4.0)
+                    .into_iter()
+                    .map(|dash| band_to_thing(&Band::new(dash, 0.8), 0.2))
+                    .sum()
+            })
+                                  .unwrap_or_else(|| Thing::new(vec![], vec![]))));
+            if lane.construction.progress - 2.0 * CONSTRUCTION_ANIMATION_DELAY >
+               lane.construction.length {
+                world.send(collector_id, Freeze(lane.id()))
+            }
+
+            Fate::Live
+        });
+
+        each_t_lane.on(|&RenderToScene { renderer_id, scene_id }, lane, world| {
+            let mut cars_iter = lane.microtraffic.cars.iter();
+            let mut current_offset = 0.0;
+            let mut car_instances = CVec::with_capacity(lane.microtraffic.cars.len());
+            for segment in lane.construction.path.segments().iter() {
+                for car in cars_iter.take_while_ref(|car| {
+                    *car.position - current_offset < segment.length()
+                }) {
+                    let position2d = segment.along(*car.position - current_offset);
+                    let direction = segment.direction_along(*car.position - current_offset);
+                    let rotated_direction = (direction +
+                                             0.3 * car.transfer_velocity * direction.orthogonal())
+                            .normalize();
+                    let shifted_position2d = position2d +
+                                             2.5 * direction.orthogonal() * car.transfer_position;
+                    car_instances.push(Instance {
+                                           instance_position: [shifted_position2d.x,
+                                                               shifted_position2d.y,
+                                                               0.0],
+                                           instance_direction: [rotated_direction.x,
+                                                                rotated_direction.y],
+                                           instance_color: if DEBUG_VIEW_LANDMARKS {
+                                               ::core::colors::RANDOM_COLORS
+                                                   [car.destination.landmark.sub_actor_id as usize %
+                                               ::core::colors::RANDOM_COLORS.len()]
+                                           } else {
+                                               ::core::colors::RANDOM_COLORS
+                                                   [car.trip.sub_actor_id as usize %
+                                               ::core::colors::RANDOM_COLORS.len()]
+                                           },
+                                       })
+                }
+                current_offset += segment.length;
+            }
+
+            if DEBUG_VIEW_TRANSFER_OBSTACLES {
+                for obstacle in &lane.microtraffic.left_obstacles {
+                    let position2d = if *obstacle.position < lane.construction.length {
+                        lane.construction.path.along(*obstacle.position)
+                    } else {
+                        lane.construction.path.end() +
+                        (*obstacle.position - lane.construction.length) *
+                        lane.construction.path.end_direction()
+                    } -
+                                     1.0 *
+                                     lane.construction
+                                         .path
+                                         .direction_along(*obstacle.position)
+                                         .orthogonal();
+                    let direction = lane.construction
+                        .path
+                        .direction_along(*obstacle.position);
+
+                    car_instances.push(Instance {
+                                           instance_position: [position2d.x, position2d.y, 0.0],
+                                           instance_direction: [direction.x, direction.y],
+                                           instance_color: [1.0, 0.7, 0.7],
+                                       });
+                }
+
+                for obstacle in &lane.microtraffic.right_obstacles {
+                    let position2d = if *obstacle.position < lane.construction.length {
+                        lane.construction.path.along(*obstacle.position)
+                    } else {
+                        lane.construction.path.end() +
+                        (*obstacle.position - lane.construction.length) *
+                        lane.construction.path.end_direction()
+                    } +
+                                     1.0 *
+                                     lane.construction
+                                         .path
+                                         .direction_along(*obstacle.position)
+                                         .orthogonal();
+                    let direction = lane.construction
+                        .path
+                        .direction_along(*obstacle.position);
+
+                    car_instances.push(Instance {
+                                           instance_position: [position2d.x, position2d.y, 0.0],
+                                           instance_direction: [direction.x, direction.y],
+                                           instance_color: [1.0, 0.7, 0.7],
+                                       });
+                }
+            }
+
+            if !car_instances.is_empty() {
+                world.send(renderer_id,
+                           AddSeveralInstances {
+                               scene_id: scene_id,
+                               batch_id: 8000,
+                               instances: car_instances,
+                           });
+            }
+
+            if lane.connectivity.left.is_none() {
+                let position = lane.construction
+                    .path
+                    .along(lane.construction.length / 2.0) +
+                               lane.construction
+                                   .path
+                                   .direction_along(lane.construction.length / 2.0)
+                                   .orthogonal();
+                world.send(renderer_id,
+                           AddInstance {
+                               scene_id: scene_id,
+                               batch_id: 1333,
+                               instance: Instance {
+                                   instance_position: [position.x, position.y, 0.0],
+                                   instance_direction: [1.0, 0.0],
+                                   instance_color: [1.0, 0.0, 0.0],
+                               },
+                           });
+            }
+            if lane.connectivity.right.is_none() {
+                let position = lane.construction
+                    .path
+                    .along(lane.construction.length / 2.0) -
+                               lane.construction
+                                   .path
+                                   .direction_along(lane.construction.length / 2.0)
+                                   .orthogonal();
+                world.send(renderer_id,
+                           AddInstance {
+                               scene_id: scene_id,
+                               batch_id: 1333,
+                               instance: Instance {
+                                   instance_position: [position.x, position.y, 0.0],
+                                   instance_direction: [1.0, 0.0],
+                                   instance_color: [1.0, 0.0, 0.0],
+                               },
+                           });
+            }
+            Fate::Live
+        })
+    }));
+
+    self::lane_thing_collector::setup::<LaneAsphalt>(system, [0.7, 0.7, 0.7], 2000, false);
+    self::lane_thing_collector::setup::<LaneMarker>(system, [1.0, 1.0, 1.0], 2100, true);
+
+    self::lane_thing_collector::setup::<TransferLaneMarkerGaps>(system,
+                                                                [0.7, 0.7, 0.7],
+                                                                2200,
+                                                                true);
 }
 
 use self::lane_thing_collector::RenderToCollector;
 use self::lane_thing_collector::Control::{Update, Freeze};
 
 const CONSTRUCTION_ANIMATION_DELAY: f32 = 120.0;
-
-impl Recipient<RenderToCollector> for Lane {
-    fn receive(&mut self, msg: &RenderToCollector) -> Fate {
-        match *msg {
-            RenderToCollector(collector_id) => {
-                let maybe_path = if self.construction.progress - CONSTRUCTION_ANIMATION_DELAY <
-                                    self.construction.length {
-                    self.construction
-                        .path
-                        .subsection(0.0,
-                                    (self.construction.progress - CONSTRUCTION_ANIMATION_DELAY)
-                                        .max(0.0))
-                } else {
-                    Some(self.construction.path.clone())
-                };
-                if collector_id == ThingCollector::<LaneAsphalt>::id() {
-                    collector_id <<
-                    Update(self.id(),
-                           maybe_path
-                               .map(|path| {
-                                        band_to_thing(&Band::new(path, 6.0),
-                                                      if self.connectivity.on_intersection {
-                                                          0.2
-                                                      } else {
-                                                          0.0
-                                                      })
-                                    })
-                               .unwrap_or_else(|| Thing::new(vec![], vec![])));
-                    if self.construction.progress - CONSTRUCTION_ANIMATION_DELAY >
-                       self.construction.length {
-                        collector_id << Freeze(self.id())
-                    }
-                } else {
-                    let left_marker = maybe_path
-                        .clone()
-                        .and_then(|path| path.shift_orthogonally(2.5))
-                        .map(|path| band_to_thing(&Band::new(path, 0.6), 0.1))
-                        .unwrap_or_else(|| Thing::new(vec![], vec![]));
-
-                    let right_marker = maybe_path
-                        .and_then(|path| path.shift_orthogonally(-2.5))
-                        .map(|path| band_to_thing(&Band::new(path, 0.6), 0.1))
-                        .unwrap_or_else(|| Thing::new(vec![], vec![]));
-                    collector_id << Update(self.id(), left_marker + right_marker);
-                    if self.construction.progress - CONSTRUCTION_ANIMATION_DELAY >
-                       self.construction.length {
-                        collector_id << Freeze(self.id())
-                    }
-                }
-
-                Fate::Live
-            }
-        }
-    }
-}
-
-impl Recipient<RenderToCollector> for TransferLane {
-    fn receive(&mut self, msg: &RenderToCollector) -> Fate {
-        match *msg {
-            RenderToCollector(collector_id) => {
-                let maybe_path = if self.construction.progress -
-                                    2.0 * CONSTRUCTION_ANIMATION_DELAY <
-                                    self.construction.length {
-                    self.construction
-                        .path
-                        .subsection(0.0,
-                                    (self.construction.progress -
-                                     2.0 * CONSTRUCTION_ANIMATION_DELAY)
-                                            .max(0.0))
-                } else {
-                    Some(self.construction.path.clone())
-                };
-
-                collector_id <<
-                Update(self.id(),
-                       maybe_path
-                           .map(|path| {
-                                    dash_path(&path, 2.0, 4.0)
-                                        .into_iter()
-                                        .map(|dash| band_to_thing(&Band::new(dash, 0.8), 0.2))
-                                        .sum()
-                                })
-                           .unwrap_or_else(|| Thing::new(vec![], vec![])));
-                if self.construction.progress - 2.0 * CONSTRUCTION_ANIMATION_DELAY >
-                   self.construction.length {
-                    collector_id << Freeze(self.id())
-                }
-
-                Fate::Live
-            }
-        }
-    }
-}
 
 use monet::RenderToScene;
 use monet::AddInstance;
@@ -190,437 +553,56 @@ const DEBUG_VIEW_SIGNALS: bool = false;
 const DEBUG_VIEW_OBSTACLES: bool = false;
 const DEBUG_VIEW_TRANSFER_OBSTACLES: bool = false;
 
-impl Recipient<RenderToScene> for Lane {
-    fn receive(&mut self, msg: &RenderToScene) -> Fate {
-        match *msg {
-            RenderToScene {
-                renderer_id,
-                scene_id,
-            } => {
-                let mut cars_iter = self.microtraffic.cars.iter();
-                let mut current_offset = 0.0;
-                let mut car_instances = CVec::with_capacity(self.microtraffic.cars.len());
-                for segment in self.construction.path.segments().iter() {
-                    for car in cars_iter.take_while_ref(|car| {
-                                                            *car.position - current_offset <
-                                                            segment.length()
-                                                        }) {
-                        let position2d = segment.along(*car.position - current_offset);
-                        let direction = segment.direction_along(*car.position - current_offset);
-                        car_instances.push(Instance{
-                        instance_position: [position2d.x, position2d.y, 0.0],
-                        instance_direction: [direction.x, direction.y],
-                        instance_color: if DEBUG_VIEW_LANDMARKS {
-                            ::core::colors::RANDOM_COLORS[
-                                car.destination.landmark.sub_actor_id as usize
-                                    % ::core::colors::RANDOM_COLORS.len()
-                            ]
-                        } else {
-                            ::core::colors::RANDOM_COLORS[
-                                car.trip.sub_actor_id as usize
-                                    % ::core::colors::RANDOM_COLORS.len()
-                            ]
-                        }
-                    })
-                    }
-                    current_offset += segment.length;
-                }
-
-                if DEBUG_VIEW_OBSTACLES {
-                    for &(obstacle, _id) in &self.microtraffic.obstacles {
-                        let position2d = if *obstacle.position < self.construction.length {
-                            self.construction.path.along(*obstacle.position)
-                        } else {
-                            self.construction.path.end() +
-                            (*obstacle.position - self.construction.length) *
-                            self.construction.path.end_direction()
-                        };
-                        let direction = self.construction
-                            .path
-                            .direction_along(*obstacle.position);
-
-                        car_instances.push(Instance {
-                                               instance_position: [position2d.x, position2d.y, 0.0],
-                                               instance_direction: [direction.x, direction.y],
-                                               instance_color: [1.0, 0.0, 0.0],
-                                           });
-                    }
-                }
-
-                if !car_instances.is_empty() {
-                    renderer_id <<
-                    AddSeveralInstances {
-                        scene_id: scene_id,
-                        batch_id: 8000,
-                        instances: car_instances,
-                    };
-                }
-                //                         no traffic light for u-turn
-                if self.connectivity.on_intersection &&
-                   !self.construction
-                        .path
-                        .end_direction()
-                        .is_roughly_within(-self.construction.path.start_direction(), 0.1) {
-                    let mut position = self.construction.path.start();
-                    let (position_shift, batch_id) = if
-                        !self.construction
-                             .path
-                             .start_direction()
-                             .is_roughly_within(self.construction.path.end_direction(), 0.5) {
-                        let dot = self.construction
-                            .path
-                            .end_direction()
-                            .dot(&self.construction.path.start_direction().orthogonal());
-                        let shift = if dot > 0.0 { 1.0 } else { -1.0 };
-                        let batch_id = if dot > 0.0 { 8004 } else { 8003 };
-                        (shift, batch_id)
-                    } else {
-                        (0.0, 8002)
-                    };
-                    position += self.construction.path.start_direction().orthogonal() *
-                                position_shift;
-                    let direction = self.construction.path.start_direction();
-
-                    renderer_id <<
-                    AddInstance {
-                        scene_id: scene_id,
-                        batch_id: 8001,
-                        instance: Instance {
-                            instance_position: [position.x, position.y, 6.0],
-                            instance_direction: [direction.x, direction.y],
-                            instance_color: [0.1, 0.1, 0.1],
-                        },
-                    };
-
-                    if self.microtraffic.yellow_to_red && self.microtraffic.green {
-                        renderer_id <<
-                        AddInstance {
-                            scene_id: scene_id,
-                            batch_id: batch_id,
-                            instance: Instance {
-                                instance_position: [position.x, position.y, 6.7],
-                                instance_direction: [direction.x, direction.y],
-                                instance_color: [1.0, 0.8, 0.0],
-                            },
-                        }
-                    } else if self.microtraffic.green {
-                        renderer_id <<
-                        AddInstance {
-                            scene_id: scene_id,
-                            batch_id: batch_id,
-                            instance: Instance {
-                                instance_position: [position.x, position.y, 6.1],
-                                instance_direction: [direction.x, direction.y],
-                                instance_color: [0.0, 1.0, 0.2],
-                            },
-                        }
-                    }
-
-                    if !self.microtraffic.green {
-                        renderer_id <<
-                        AddInstance {
-                            scene_id: scene_id,
-                            batch_id: batch_id,
-                            instance: Instance {
-                                instance_position: [position.x, position.y, 7.3],
-                                instance_direction: [direction.x, direction.y],
-                                instance_color: [1.0, 0.0, 0.0],
-                            },
-                        };
-
-                        if self.microtraffic.yellow_to_green {
-                            renderer_id <<
-                            AddInstance {
-                                scene_id: scene_id,
-                                batch_id: batch_id,
-                                instance: Instance {
-                                    instance_position: [position.x, position.y, 6.7],
-                                    instance_direction: [direction.x, direction.y],
-                                    instance_color: [1.0, 0.8, 0.0],
-                                },
-                            }
-                        }
-                    }
-                }
-
-                if DEBUG_VIEW_SIGNALS && self.connectivity.on_intersection {
-                    renderer_id <<
-                    UpdateThing {
-                        scene_id: scene_id,
-                        thing_id: 4000 + self.id().sub_actor_id as u16,
-                        thing: band_to_thing(&Band::new(self.construction.path.clone(), 0.3),
-                                             if self.microtraffic.green { 0.4 } else { 0.2 }),
-                        instance: Instance::with_color(if self.microtraffic.green {
-                                                           [0.0, 1.0, 0.0]
-                                                       } else {
-                                                           [1.0, 0.0, 0.0]
-                                                       }),
-                        is_decal: true,
-                    };
-                }
-
-                if !self.connectivity
-                        .interactions
-                        .iter()
-                        .any(|inter| match inter.kind {
-                                 InteractionKind::Next { .. } => true,
-                                 _ => false,
-                             }) {
-                    renderer_id <<
-                    AddInstance {
-                        scene_id: scene_id,
-                        batch_id: 1333,
-                        instance: Instance {
-                            instance_position: [self.construction.path.end().x,
-                                                self.construction.path.end().y,
-                                                0.5],
-                            instance_direction: [1.0, 0.0],
-                            instance_color: [1.0, 0.0, 0.0],
-                        },
-                    };
-                }
-
-                if !self.connectivity
-                        .interactions
-                        .iter()
-                        .any(|inter| match inter.kind {
-                                 InteractionKind::Previous { .. } => true,
-                                 _ => false,
-                             }) {
-                    renderer_id <<
-                    AddInstance {
-                        scene_id: scene_id,
-                        batch_id: 1333,
-                        instance: Instance {
-                            instance_position: [self.construction.path.start().x,
-                                                self.construction.path.start().y,
-                                                0.5],
-                            instance_direction: [1.0, 0.0],
-                            instance_color: [0.0, 1.0, 0.0],
-                        },
-                    };
-                }
-
-                if DEBUG_VIEW_LANDMARKS && self.pathfinding.routes_changed {
-                    let (random_color, is_landmark) = if let Some(as_destination) =
-                        self.pathfinding.as_destination {
-                        let random_color: [f32; 3] = ::core::colors::RANDOM_COLORS
-                            [as_destination.landmark.sub_actor_id as usize %
-                        ::core::colors::RANDOM_COLORS.len()];
-                        let weaker_random_color = [(random_color[0] + 1.0) / 2.0,
-                                                   (random_color[1] + 1.0) / 2.0,
-                                                   (random_color[2] + 1.0) / 2.0];
-                        (weaker_random_color, as_destination.is_landmark())
-                    } else {
-                        ([1.0, 1.0, 1.0], false)
-                    };
-
-                    renderer_id <<
-                    UpdateThing {
-                        scene_id: scene_id,
-                        thing_id: 4000 + self.id().sub_actor_id as u16,
-                        thing: band_to_thing(&Band::new(self.construction.path.clone(),
-                                                        if is_landmark { 2.5 } else { 1.0 }),
-                                             0.4),
-                        instance: Instance::with_color(random_color),
-                        is_decal: true,
-                    };
-                }
-                Fate::Live
-            }
-        }
-    }
-}
-
-impl Recipient<RenderToScene> for TransferLane {
-    fn receive(&mut self, msg: &RenderToScene) -> Fate {
-        match *msg {
-            RenderToScene {
-                renderer_id,
-                scene_id,
-            } => {
-                let mut cars_iter = self.microtraffic.cars.iter();
-                let mut current_offset = 0.0;
-                let mut car_instances = CVec::with_capacity(self.microtraffic.cars.len());
-                for segment in self.construction.path.segments().iter() {
-                    for car in cars_iter.take_while_ref(|car| {
-                                                            *car.position - current_offset <
-                                                            segment.length()
-                                                        }) {
-                        let position2d = segment.along(*car.position - current_offset);
-                        let direction = segment.direction_along(*car.position - current_offset);
-                        let rotated_direction =
-                            (direction + 0.3 * car.transfer_velocity * direction.orthogonal())
-                                .normalize();
-                        let shifted_position2d =
-                            position2d + 2.5 * direction.orthogonal() * car.transfer_position;
-                        car_instances.push(Instance{
-                            instance_position: [shifted_position2d.x, shifted_position2d.y, 0.0],
-                            instance_direction: [rotated_direction.x, rotated_direction.y],
-                            instance_color: if DEBUG_VIEW_LANDMARKS {
-                                ::core::colors::RANDOM_COLORS[
-                                    car.destination.landmark.sub_actor_id as usize
-                                        % ::core::colors::RANDOM_COLORS.len()
-                                ]
-                            } else {
-                                ::core::colors::RANDOM_COLORS[
-                                    car.trip.sub_actor_id as usize
-                                        % ::core::colors::RANDOM_COLORS.len()
-                                ]
-                            }
-                        })
-                    }
-                    current_offset += segment.length;
-                }
-
-                if DEBUG_VIEW_TRANSFER_OBSTACLES {
-                    for obstacle in &self.microtraffic.left_obstacles {
-                        let position2d = if *obstacle.position < self.construction.length {
-                            self.construction.path.along(*obstacle.position)
-                        } else {
-                            self.construction.path.end() +
-                            (*obstacle.position - self.construction.length) *
-                            self.construction.path.end_direction()
-                        } -
-                                         1.0 *
-                                         self.construction
-                                             .path
-                                             .direction_along(*obstacle.position)
-                                             .orthogonal();
-                        let direction = self.construction
-                            .path
-                            .direction_along(*obstacle.position);
-
-                        car_instances.push(Instance {
-                                               instance_position: [position2d.x, position2d.y, 0.0],
-                                               instance_direction: [direction.x, direction.y],
-                                               instance_color: [1.0, 0.7, 0.7],
-                                           });
-                    }
-
-                    for obstacle in &self.microtraffic.right_obstacles {
-                        let position2d = if *obstacle.position < self.construction.length {
-                            self.construction.path.along(*obstacle.position)
-                        } else {
-                            self.construction.path.end() +
-                            (*obstacle.position - self.construction.length) *
-                            self.construction.path.end_direction()
-                        } +
-                                         1.0 *
-                                         self.construction
-                                             .path
-                                             .direction_along(*obstacle.position)
-                                             .orthogonal();
-                        let direction = self.construction
-                            .path
-                            .direction_along(*obstacle.position);
-
-                        car_instances.push(Instance {
-                                               instance_position: [position2d.x, position2d.y, 0.0],
-                                               instance_direction: [direction.x, direction.y],
-                                               instance_color: [1.0, 0.7, 0.7],
-                                           });
-                    }
-                }
-
-                if !car_instances.is_empty() {
-                    renderer_id <<
-                    AddSeveralInstances {
-                        scene_id: scene_id,
-                        batch_id: 8000,
-                        instances: car_instances,
-                    };
-                }
-
-                if self.connectivity.left.is_none() {
-                    let position = self.construction
-                        .path
-                        .along(self.construction.length / 2.0) +
-                                   self.construction
-                                       .path
-                                       .direction_along(self.construction.length / 2.0)
-                                       .orthogonal();
-                    renderer_id <<
-                    AddInstance {
-                        scene_id: scene_id,
-                        batch_id: 1333,
-                        instance: Instance {
-                            instance_position: [position.x, position.y, 0.0],
-                            instance_direction: [1.0, 0.0],
-                            instance_color: [1.0, 0.0, 0.0],
-                        },
-                    };
-                }
-                if self.connectivity.right.is_none() {
-                    let position = self.construction
-                        .path
-                        .along(self.construction.length / 2.0) -
-                                   self.construction
-                                       .path
-                                       .direction_along(self.construction.length / 2.0)
-                                       .orthogonal();
-                    renderer_id <<
-                    AddInstance {
-                        scene_id: scene_id,
-                        batch_id: 1333,
-                        instance: Instance {
-                            instance_position: [position.x, position.y, 0.0],
-                            instance_direction: [1.0, 0.0],
-                            instance_color: [1.0, 0.0, 0.0],
-                        },
-                    };
-                }
-                Fate::Live
-            }
-        }
-    }
-}
-
 use self::lane_thing_collector::Control::Remove;
 
-pub fn on_build(lane: &Lane) {
-    lane.id() << RenderToCollector(ThingCollector::<LaneAsphalt>::id());
+pub fn on_build(lane: &Lane, world: &mut World) {
+    let asphalt_coll_id = world.id::<ThingCollector<LaneAsphalt>>();
+    let marker_coll_id = world.id::<ThingCollector<LaneMarker>>();
+    world.send(lane.id(), RenderToCollector(asphalt_coll_id));
     if !lane.connectivity.on_intersection {
-        lane.id() << RenderToCollector(ThingCollector::<LaneMarker>::id());
+        world.send(lane.id(), RenderToCollector(marker_coll_id));
     }
 }
 
-pub fn on_build_transfer(lane: &TransferLane) {
-    lane.id() << RenderToCollector(ThingCollector::<TransferLaneMarkerGaps>::id());
+pub fn on_build_transfer(lane: &TransferLane, world: &mut World) {
+    let marker_coll_id = world.id::<ThingCollector<TransferLaneMarkerGaps>>();
+    world.send(lane.id(), RenderToCollector(marker_coll_id));
 }
 
-pub fn on_unbuild(lane: &Lane) {
-    ThingCollector::<LaneAsphalt>::id() << Remove(lane.id());
+pub fn on_unbuild(lane: &Lane, world: &mut World) {
+    world.send_to_id_of::<ThingCollector<LaneAsphalt>, _>(Remove(lane.id()));
     if !lane.connectivity.on_intersection {
-        ThingCollector::<LaneMarker>::id() << Remove(lane.id());
+        world.send_to_id_of::<ThingCollector<LaneMarker>, _>(Remove(lane.id()));
     }
 
     if DEBUG_VIEW_LANDMARKS {
         // TODO: ugly
-        ::monet::Renderer::id() <<
-        UpdateThing {
-            scene_id: 0,
-            thing_id: 4000 + lane.id().sub_actor_id as u16,
-            thing: Thing::new(vec![], vec![]),
-            instance: Instance::with_color([0.0, 0.0, 0.0]),
-            is_decal: true,
-        };
+        world.send_to_id_of::<::monet::Renderer, _>(UpdateThing {
+                                                        scene_id: 0,
+                                                        thing_id: 4000 +
+                                                                  lane.id().sub_actor_id as u16,
+                                                        thing: Thing::new(vec![], vec![]),
+                                                        instance: Instance::with_color([0.0, 0.0,
+                                                                                        0.0]),
+                                                        is_decal: true,
+                                                    });
     }
 
     if DEBUG_VIEW_SIGNALS {
-        ::monet::Renderer::id() <<
-        UpdateThing {
-            scene_id: 0,
-            thing_id: 4000 + lane.id().sub_actor_id as u16,
-            thing: Thing::new(vec![], vec![]),
-            instance: Instance::with_color([0.0, 0.0, 0.0]),
-            is_decal: true,
-        };
+        world.send_to_id_of::<::monet::Renderer, _>(UpdateThing {
+                                                        scene_id: 0,
+                                                        thing_id: 4000 +
+                                                                  lane.id().sub_actor_id as u16,
+                                                        thing: Thing::new(vec![], vec![]),
+                                                        instance: Instance::with_color([0.0, 0.0,
+                                                                                        0.0]),
+                                                        is_decal: true,
+                                                    });
     }
 }
 
-pub fn on_unbuild_transfer(lane: &TransferLane) {
-    ThingCollector::<TransferLaneMarkerGaps>::id() << Remove(lane.id());
+pub fn on_unbuild_transfer(lane: &TransferLane, world: &mut World) {
+    world.send_to_id_of::<ThingCollector<TransferLaneMarkerGaps>, _>(Remove(lane.id()));
 }
 
 #[derive(Clone)]
@@ -629,16 +611,3 @@ pub struct LaneAsphalt;
 pub struct LaneMarker;
 #[derive(Clone)]
 pub struct TransferLaneMarkerGaps;
-
-pub fn setup() {
-    Swarm::<Lane>::handle::<SetupInScene>();
-    Swarm::<Lane>::handle::<RenderToCollector>();
-    Swarm::<Lane>::handle::<RenderToScene>();
-    self::lane_thing_collector::setup::<LaneAsphalt>([0.7, 0.7, 0.7], 2000, false);
-    self::lane_thing_collector::setup::<LaneMarker>([1.0, 1.0, 1.0], 2100, true);
-
-    Swarm::<TransferLane>::handle::<SetupInScene>();
-    Swarm::<TransferLane>::handle::<RenderToCollector>();
-    Swarm::<TransferLane>::handle::<RenderToScene>();
-    self::lane_thing_collector::setup::<TransferLaneMarkerGaps>([0.7, 0.7, 0.7], 2200, true);
-}

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -1,9 +1,10 @@
+use kay::ActorSystem;
 pub mod lanes_and_cars;
 
-pub fn setup() {
-    lanes_and_cars::setup();
+pub fn setup(system: &mut ActorSystem) {
+    lanes_and_cars::setup(system);
 }
 
-pub fn setup_ui() {
-    lanes_and_cars::setup_ui();
+pub fn setup_ui(system: &mut ActorSystem) {
+    lanes_and_cars::setup_ui(system);
 }


### PR DESCRIPTION
This huge refactor was triggered by @kingoflolz, reminding me that defining actors was annoying. So I made it better, and at the same time removed a lot of magic around `kay`

Old example:

```rust
impl Recipient<SetPoints> for StrokeCanvas {
    fn receive(&mut self, msg: &SetPoints) -> Fate {
        match *msg {
            SetPoints(ref points) => {
                self.points = points.clone();
                Fate::Live
            }
        }
    }
}

impl Recipient<InitInteractable> for StrokeCanvas {
    fn receive(&mut self, _msg: &InitInteractable) -> Fate {
        UserInterface::id() << AddInteractable(StrokeCanvas::id(), AnyShape::Everywhere, 1);
        Fate::Live
    }
}

// ... other handler definitions

// ... further down ...

pub fn setup() {
    StrokeCanvas::register_default();
    // ... other handler registrations
    StrokeCanvas::handle::<SetPoints>();
    // ... other handler registrations
}
```

New example:

```rust

pub fn setup(system: &mut ActorSystem) {
    system.add(StrokeCanvas::default(), |mut the_canvas| {
        let ui_id = the_canvas.world().id::<UserInterface>();
        let canvas_id = the_canvas.world().id::<StrokeCanvas>();

        the_canvas.on(|&SetPoints(ref points), canvas, _| {
            canvas.points = points.clone();
            Fate::Live
        });

        the_canvas.on(move |_: &InitInteractable, _, world| {
            world.send(ui_id, AddInteractable(canvas_id, AnyShape::Everywhere, 1));
            Fate::Live
        });

        // ... other handler definitions + registrations
    });
}
```

Improvements:

* no separate definition/registration needed, much more compact!
* use closures, in many cases pull pattern matching directly into closure arguments!
* sending messages and looking up ids is explicit instead of mutating a hidden global actor system

TODO:

- [ ] Update kay docs (I'll do it)