### PR TITLE
fix for 'attempt to subtract with overflow' in lane.rs

### DIFF
--- a/src/game/lanes_and_cars/lane.rs
+++ b/src/game/lanes_and_cars/lane.rs
@@ -72,7 +72,9 @@ impl TransferLane {
         #[allow(needless_range_loop)]
         for i in 0..map.len() {
             let (next_self, next_other) = map[i];
-            let &(prev_self, prev_other) = map.get(i - 1).unwrap_or(&(0.0, 0.0));
+            let &(prev_self, prev_other) = i.checked_sub(1)
+                .and_then(|p| map.get(p))
+                .unwrap_or(&(0.0, 0.0));
             if prev_other <= distance_on_interaction && next_other >= distance_on_interaction {
                 let amount_of_segment = (distance_on_interaction - prev_other) /
                                         (next_other - prev_other);
@@ -92,7 +94,9 @@ impl TransferLane {
         #[allow(needless_range_loop)]
         for i in 0..map.len() {
             let (next_self, next_other) = map[i];
-            let &(prev_self, prev_other) = map.get(i - 1).unwrap_or(&(0.0, 0.0));
+            let &(prev_self, prev_other) = i.checked_sub(1)
+                .and_then(|p| map.get(p))
+                .unwrap_or(&(0.0, 0.0));
             if prev_self <= distance_on_self && next_self >= distance_on_self {
                 let amount_of_segment = (distance_on_self - prev_self) / (next_self - prev_self);
                 let distance_on_other = prev_other + amount_of_segment * (next_other - prev_other);


### PR DESCRIPTION
Hi!

Thank you, citybound is a cool endeavour!

Please consider merging a fix for 
```
thread 'main' panicked at 'attempt to subtract with overflow', src/game/lanes_and_cars/lane.rs:75
stack backtrace:
   0: std::sys::imp::backtrace::tracing::imp::unwind_backtrace
   1: std::panicking::default_hook::{{closure}}
   2: std::panicking::default_hook
   3: std::panicking::rust_panic_with_hook
   4: std::panicking::begin_panic
   5: std::panicking::begin_panic_fmt
   6: rust_begin_unwind
   7: core::panicking::panic_fmt
   8: core::panicking::panic
   9: citybound::game::lanes_and_cars::lane::TransferLane::interaction_to_self_offset
  10: citybound::game::lanes_and_cars::microtraffic::setup::{{closure}}::{{closure}}
  11: <kay::swarm::Swarm<SA>>::receive_instance
  12: kay::actor_system::ActorSystem::single_message_cycle
  13: kay::actor_system::ActorSystem::process_all_messages::{{closure}}
  14: core::ops::FnOnce::call_once
  15: __rust_maybe_catch_panic
  16: std::panicking::try
  17: std::panic::catch_unwind
  18: kay::actor_system::ActorSystem::process_all_messages
  19: citybound::main
  20: __rust_maybe_catch_panic
  21: std::rt::lang_start
Simulation Panic!
"attempt to subtract with overflow"
```

Best wishes,
Vladimir