### PR TITLE
fix current_plan::rendering::render_intersections 'attempt to add with overflow', Thing::indices u16->u32

### DIFF
--- a/lib/monet/src/geometry.rs
+++ b/lib/monet/src/geometry.rs
@@ -9,7 +9,7 @@ use Thing;
 
 pub struct Batch {
     pub vertices: glium::VertexBuffer<Vertex>,
-    pub indices: glium::IndexBuffer<u16>,
+    pub indices: glium::IndexBuffer<u32>,
     pub instances: Vec<Instance>,
     pub clear_every_frame: bool,
     pub is_decal: bool,

--- a/lib/monet/src/thing.rs
+++ b/lib/monet/src/thing.rs
@@ -6,11 +6,11 @@ use Vertex;
 #[derive(Compact, Debug)]
 pub struct Thing {
     pub vertices: CVec<Vertex>,
-    pub indices: CVec<u16>,
+    pub indices: CVec<u32>,
 }
 
 impl Thing {
-    pub fn new(vertices: Vec<Vertex>, indices: Vec<u16>) -> Thing {
+    pub fn new(vertices: Vec<Vertex>, indices: Vec<u32>) -> Thing {
         Thing {
             vertices: vertices.into(),
             indices: indices.into(),
@@ -40,7 +40,7 @@ impl ::std::ops::Add for Thing {
                    self.indices
                        .iter()
                        .cloned()
-                       .chain(rhs.indices.iter().map(|i| *i + self_n_vertices as u16))
+                       .chain(rhs.indices.iter().map(|i| *i + self_n_vertices as u32))
                        .collect())
     }
 }
@@ -52,7 +52,7 @@ impl ::std::ops::AddAssign for Thing {
             self.vertices.push(vertex);
         }
         for index in rhs.indices.iter() {
-            self.indices.push(index + self_n_vertices as u16)
+            self.indices.push(index + self_n_vertices as u32)
         }
     }
 }
@@ -77,7 +77,7 @@ impl<'a> ::std::ops::AddAssign<&'a Thing> for Thing {
             self.vertices.push(vertex);
         }
         for index in rhs.indices.iter() {
-            self.indices.push(index + self_n_vertices as u16)
+            self.indices.push(index + self_n_vertices as u32)
         }
     }
 }

--- a/lib/stagemaster/src/geometry.rs
+++ b/lib/stagemaster/src/geometry.rs
@@ -79,10 +79,10 @@ const CURVE_LINEARIZATION_MAX_ANGLE: f32 = 0.03;
 
 pub fn band_to_thing<P: Path>(band: &Band<P>, z: N) -> Thing {
     let mut vertices = Vec::<Vertex>::new();
-    let mut indices = Vec::<u16>::new();
+    let mut indices = Vec::<u32>::new();
     for segment in band.path.segments() {
         if segment.is_linear() {
-            let first_new_vertex = vertices.len() as u16;
+            let first_new_vertex = vertices.len() as u32;
             let orth_direction = segment.center_or_direction.orthogonal();
             vertices.push(to_vertex(segment.start + band.width / 2.0 * orth_direction, z));
             vertices.push(to_vertex(segment.start - band.width / 2.0 * orth_direction, z));
@@ -108,7 +108,7 @@ pub fn band_to_thing<P: Path>(band: &Band<P>, z: N) -> Thing {
             vertices.push(to_vertex(position - band.width / 2.0 * orth_direction, z));
 
             for subdivision in 0..subdivisions {
-                let first_new_vertex = vertices.len() as u16;
+                let first_new_vertex = vertices.len() as u32;
                 let distance = (subdivision + 1) as f32 * distance_per_subdivision;
                 let position = segment.along(distance);
                 let orth_direction = segment.direction_along(distance).orthogonal();

--- a/src/game/lanes_and_cars/rendering/resources/car.rs
+++ b/src/game/lanes_and_cars/rendering/resources/car.rs
@@ -109,5 +109,5 @@ pub fn create() -> ::monet::Thing {
                              7,
                              0xE,
                              7,
-                             6u16])
+                             6u32])
 }


### PR DESCRIPTION
Hi!

I stumbled upon panic upon pressing G (small grid)
```
thread 'main' panicked at 'attempt to add with overflow', /Users/travis/build/rust-lang/rust/src/libcore/ops.rs:344
stack backtrace:
   0: std::sys::imp::backtrace::tracing::imp::unwind_backtrace
   1: std::panicking::default_hook::{{closure}}
   2: std::panicking::default_hook
   3: std::panicking::rust_panic_with_hook
   4: std::panicking::begin_panic
   5: std::panicking::begin_panic_fmt
   6: rust_begin_unwind
   7: core::panicking::panic_fmt
   8: core::panicking::panic
   9: <u16 as core::ops::Add>::add
  10: <monet::thing::Thing as core::ops::AddAssign>::add_assign
  11: <monet::thing::Thing as core::iter::traits::Sum>::sum
  12: core::iter::iterator::Iterator::sum
  13: citybound::game::lanes_and_cars::planning::current_plan::rendering::render_intersections
  14: citybound::game::lanes_and_cars::planning::current_plan::rendering::setup::{{closure}}::{{closure}}
  15: kay::actor_system::ActorSystem::single_message_cycle
  16: kay::actor_system::ActorSystem::process_all_messages::{{closure}}
  17: core::ops::FnOnce::call_once
  18: __rust_maybe_catch_panic
  19: std::panicking::try
  20: std::panic::catch_unwind
  21: kay::actor_system::ActorSystem::process_all_messages
  22: citybound::main
  23: __rust_maybe_catch_panic
  24: std::rt::lang_start
```

changed the code for  ::std::ops::AddAssign for Thing to output the actual values for indices:
```
impl ::std::ops::AddAssign for Thing {
    fn add_assign(&mut self, rhs: Thing) {
        let self_n_vertices = self.vertices.len();
        for vertex in rhs.vertices.iter().cloned() {
            self.vertices.push(vertex);
        }
        for index in rhs.indices.iter() {
            let checked = index.checked_add(self_n_vertices as u32);
            if checked.is_none() {
                println!(
                    "going to panic index {:?} self_n_vertices {:?}",
                    index,
                    self_n_vertices
                );
            }
            let cur_sum = index + self_n_vertices as u32;
            self.indices.push(cur_sum);
        }
    }
}
```
and got this output:

```
citybound was compiled with optimization - stepping may behave oddly; variables may not be available.
going to panic index 3248 self_n_vertices 62288
```

Seems more vertices than Thing could index.
I do not know enough about how Thing and rendering works, 
but did the naive enlarging of index type fix, it seems not to panic any more, and the frame rate dropped insignificantly, even less so in release.

Please consider merging or ignore if you know a better solution :)
