### PR TITLE
Add G++ installation for Linux

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,7 @@ Recommended setup:
   * `rustup override add nightly-2017-10-19-x86_64-apple-darwin`
 * Linux:
   * `rustup override add nightly-2017-10-19-x86_64-unknown-linux-gnu`
+  * `sudo apt-get install g++`
 * `cargo run --release` (Debug mode is generally too slow to interact with)
 
 ## Getting the recommended dev environment

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Recommended setup:
   * `rustup override add nightly-2017-10-19-x86_64-apple-darwin`
 * Linux:
   * `rustup override add nightly-2017-10-19-x86_64-unknown-linux-gnu`
-  * `sudo apt-get install g++`
+  * `sudo apt install build-essential` (for Ubuntu)
 * `cargo run --release` (Debug mode is generally too slow to interact with)
 
 ## Getting the recommended dev environment


### PR DESCRIPTION
When you don´t install G++, you will get an error when compiling