### PR TITLE
a possible fix for plan_result_step::find_intersections Option::unwrap None

### DIFF
--- a/game/transport/planning/plan_result_steps.rs
+++ b/game/transport/planning/plan_result_steps.rs
@@ -35,15 +35,17 @@ pub fn find_intersections(strokes: &CVec<LaneStroke>) -> CVec<Intersection> {
     intersection_point_groups
         .sets()
         .filter_map(|group| if group.len() >= 2 {
-            Some(Intersection {
-                shape: convex_hull::<CPath>(group)
-                    .shift_orthogonally(-5.0)
-                    .unwrap(),
-                incoming: CDict::new(),
-                outgoing: CDict::new(),
-                strokes: CVec::new(),
-                timings: CVec::new(),
-            })
+            convex_hull::<CPath>(group).shift_orthogonally(-5.0).map(
+                |shape| {
+                    Intersection {
+                        shape: shape,
+                        incoming: CDict::new(),
+                        outgoing: CDict::new(),
+                        strokes: CVec::new(),
+                        timings: CVec::new(),
+                    }
+                },
+            )
         } else {
             None
         })


### PR DESCRIPTION
Hi @aeickhoff!

I think I fixed the plan_result_step::find_intersections Option::unwrap None crash,

<img width="718" alt="screenshot 2017-10-29 15 56 36" src="https://user-images.githubusercontent.com/65818/32145791-53c6b2b4-bcce-11e7-83b6-6b88df3d6528.png">

Added some debug output and found that 
```
shift ortogonally is about to return None
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', src/libcore/option.rs:335:20
stack backtrace:
   0: std::sys::imp::backtrace::tracing::imp::unwind_backtrace
   1: std::sys_common::backtrace::_print
   2: std::panicking::default_hook::{{closure}}
   3: std::panicking::default_hook
   4: std::panicking::rust_panic_with_hook
   5: std::panicking::begin_panic
   6: std::panicking::begin_panic_fmt
   7: rust_begin_unwind
   8: core::panicking::panic_fmt
   9: core::panicking::panic
  10: <compact::compact_vec::CompactVec<T, A> as core::iter::traits::FromIterator<T>>::from_iter
  11: citybound::transport::planning::plan_result_steps::find_intersections
  12: citybound::transport::planning::plan::Plan::get_result
  13: citybound::transport::construction::materialized_reality::kay_auto::auto_setup::{{closure}}
  14: <kay::swarm::Swarm<A>>::dispatch_packet
  15: kay::actor_system::ActorSystem::add_handler::{{closure}}
  16: kay::actor_system::ActorSystem::single_message_cycle
  17: <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
  18: __rust_maybe_catch_panic
  19: std::panicking::try
  20: std::panic::catch_unwind
  21: kay::actor_system::ActorSystem::process_all_messages
  22: citybound::core::init::ensure_crossplatform_proper_thread
  23: __rust_maybe_catch_panic
  24: std::rt::lang_start
```

Seems 
find_intersections assumes Path shift_orthogonally cannot  return None, 
but seems it can, that probably happens when the Segments are start.is_roughly_within(end, MIN_START_TO_END) and there are all of them with this property.

Please consider merging it, I'm returning None as an Intersection in that case. This crash happens not very often, so I cannot reproduce it reliably.

The only thing which concerns me as I don't have a clear understanding of Segment/Path/Intersection yet, so feel free to decline :)

That might fix https://github.com/citybound/citybound/issues/146, 

Best wishes,
Vladimir