### PR TITLE
fix for 'citybound release crashes with invalid instruction (ud2)'

### DIFF
--- a/game/economy/households/bakery/mod.rs
+++ b/game/economy/households/bakery/mod.rs
@@ -1,12 +1,11 @@
-use kay::{ActorSystem, World, TypedID, Actor};
-use core::simulation::{TimeOfDay, TimeOfDayRange, Duration, SimulationID, Ticks};
+use kay::{Actor, ActorSystem, TypedID, World};
+use core::simulation::{Duration, SimulationID, Ticks, TimeOfDay, TimeOfDayRange};
 use economy::resources::Resource;
 use economy::resources::Resource::*;
-use economy::market::{Deal, EvaluationRequester, EvaluationRequesterID, EvaluatedSearchResult};
+use economy::market::{Deal, EvaluatedSearchResult, EvaluationRequester, EvaluationRequesterID};
 use economy::buildings::BuildingID;
 
-use super::{Household, HouseholdID, HouseholdCore, MemberIdx, Offer};
-
+use super::{Household, HouseholdCore, HouseholdID, MemberIdx, Offer};
 
 #[derive(Compact, Clone)]
 pub struct Bakery {
@@ -49,7 +48,7 @@ impl Bakery {
                     Offer::new(
                         MemberIdx(0),
                         TimeOfDayRange::new(5, 0, 15, 0),
-                        Deal::new(Some((Resource::Money, 50.0)), Duration::from_hours(5)),
+                        Deal::new(vec![(Resource::Money, 50.0)], Duration::from_hours(5)),
                         3,
                         false
                     ),
@@ -132,7 +131,7 @@ impl Household for Bakery {
     }
 }
 
-use core::simulation::{Simulatable, SimulatableID, Sleeper, SleeperID, Instant,
+use core::simulation::{Instant, Simulatable, SimulatableID, Sleeper, SleeperID,
                        TICKS_PER_SIM_SECOND};
 const UPDATE_EVERY_N_SECS: usize = 4;
 
@@ -157,7 +156,7 @@ impl EvaluationRequester for Bakery {
     fn on_result(&mut self, _e: &EvaluatedSearchResult, _: &mut World) {}
 }
 
-use transport::pathfinding::{RoughLocationID, RoughLocation, RoughLocationResolve};
+use transport::pathfinding::{RoughLocation, RoughLocationID, RoughLocationResolve};
 
 impl RoughLocation for Bakery {
     fn resolve(&self) -> RoughLocationResolve {
@@ -165,7 +164,7 @@ impl RoughLocation for Bakery {
     }
 }
 
-use transport::pathfinding::trip::{TripListener, TripListenerID, TripID, TripResult};
+use transport::pathfinding::trip::{TripID, TripListener, TripListenerID, TripResult};
 
 impl TripListener for Bakery {
     fn trip_created(&mut self, trip: TripID, world: &mut World) {

--- a/game/economy/households/cow_farm/mod.rs
+++ b/game/economy/households/cow_farm/mod.rs
@@ -1,12 +1,11 @@
-use kay::{ActorSystem, World, TypedID, Actor};
-use core::simulation::{TimeOfDay, TimeOfDayRange, Duration, SimulationID, Ticks};
+use kay::{Actor, ActorSystem, TypedID, World};
+use core::simulation::{Duration, SimulationID, Ticks, TimeOfDay, TimeOfDayRange};
 use economy::resources::Resource;
 use economy::resources::Resource::*;
-use economy::market::{Deal, EvaluationRequester, EvaluationRequesterID, EvaluatedSearchResult};
+use economy::market::{Deal, EvaluatedSearchResult, EvaluationRequester, EvaluationRequesterID};
 use economy::buildings::BuildingID;
 
-use super::{Household, HouseholdID, HouseholdCore, MemberIdx, Offer};
-
+use super::{Household, HouseholdCore, HouseholdID, MemberIdx, Offer};
 
 #[derive(Compact, Clone)]
 pub struct CowFarm {
@@ -59,7 +58,7 @@ impl CowFarm {
                     Offer::new(
                         MemberIdx(0),
                         TimeOfDayRange::new(5, 0, 15, 0),
-                        Deal::new(Some((Resource::Money, 40.0)), Duration::from_hours(4)),
+                        Deal::new(vec![(Resource::Money, 40.0)], Duration::from_hours(4)),
                         2,
                         false
                     ),
@@ -142,7 +141,7 @@ impl Household for CowFarm {
     }
 }
 
-use core::simulation::{Simulatable, SimulatableID, Sleeper, SleeperID, Instant,
+use core::simulation::{Instant, Simulatable, SimulatableID, Sleeper, SleeperID,
                        TICKS_PER_SIM_SECOND};
 const UPDATE_EVERY_N_SECS: usize = 4;
 
@@ -167,7 +166,7 @@ impl EvaluationRequester for CowFarm {
     fn on_result(&mut self, _e: &EvaluatedSearchResult, _: &mut World) {}
 }
 
-use transport::pathfinding::{RoughLocationID, RoughLocation, RoughLocationResolve};
+use transport::pathfinding::{RoughLocation, RoughLocationID, RoughLocationResolve};
 
 impl RoughLocation for CowFarm {
     fn resolve(&self) -> RoughLocationResolve {
@@ -175,7 +174,7 @@ impl RoughLocation for CowFarm {
     }
 }
 
-use transport::pathfinding::trip::{TripListener, TripListenerID, TripID, TripResult};
+use transport::pathfinding::trip::{TripID, TripListener, TripListenerID, TripResult};
 
 impl TripListener for CowFarm {
     fn trip_created(&mut self, trip: TripID, world: &mut World) {

--- a/game/economy/households/family/mod.rs
+++ b/game/economy/households/family/mod.rs
@@ -1,19 +1,19 @@
-use kay::{ActorSystem, World, Actor};
+use kay::{Actor, ActorSystem, World};
 use core::random::{seed, Rng};
 
-use core::simulation::{TimeOfDay, TimeOfDayRange, Instant, Duration, Ticks, SimulationID,
-                       Simulatable, SimulatableID};
+use core::simulation::{Duration, Instant, Simulatable, SimulatableID, SimulationID, Ticks,
+                       TimeOfDay, TimeOfDayRange};
 use economy::resources::Resource;
 use economy::resources::Resource::*;
-use economy::market::{Deal, EvaluationRequester, EvaluationRequesterID, EvaluatedSearchResult};
+use economy::market::{Deal, EvaluatedSearchResult, EvaluationRequester, EvaluationRequesterID};
 use economy::buildings::BuildingID;
-use transport::pathfinding::trip::{TripResult, TripListenerID};
+use transport::pathfinding::trip::{TripListenerID, TripResult};
 use transport::pathfinding::RoughLocationID;
 
 pub mod names;
 use self::names::{family_name, member_name};
 
-use super::{Household, HouseholdID, HouseholdCore, MemberIdx, Offer, OfferID, OfferIdx};
+use super::{Household, HouseholdCore, HouseholdID, MemberIdx, Offer, OfferID, OfferIdx};
 
 #[derive(Compact, Clone)]
 pub struct Family {
@@ -41,7 +41,7 @@ impl Family {
                 Offer::new(
                     MemberIdx(0),
                     TimeOfDayRange::new(16, 0, 11, 0),
-                    Deal::new(Some((Awakeness, 3.0)), Duration::from_hours(1)),
+                    Deal::new(vec![(Awakeness, 3.0)], Duration::from_hours(1)),
                     1,
                     true
                 ),
@@ -82,7 +82,7 @@ impl EvaluationRequester for Family {
     }
 }
 
-use transport::pathfinding::trip::{TripListener, TripID};
+use transport::pathfinding::trip::{TripID, TripListener};
 
 impl TripListener for Family {
     fn trip_created(&mut self, trip: TripID, world: &mut World) {

--- a/game/economy/households/grain_farm/mod.rs
+++ b/game/economy/households/grain_farm/mod.rs
@@ -1,12 +1,11 @@
-use kay::{ActorSystem, World, TypedID, Actor};
-use core::simulation::{TimeOfDay, TimeOfDayRange, Duration, SimulationID, Ticks};
+use kay::{Actor, ActorSystem, TypedID, World};
+use core::simulation::{Duration, SimulationID, Ticks, TimeOfDay, TimeOfDayRange};
 use economy::resources::Resource;
 use economy::resources::Resource::*;
-use economy::market::{Deal, EvaluationRequester, EvaluationRequesterID, EvaluatedSearchResult};
+use economy::market::{Deal, EvaluatedSearchResult, EvaluationRequester, EvaluationRequesterID};
 use economy::buildings::BuildingID;
 
-use super::{Household, HouseholdID, HouseholdCore, MemberIdx, Offer};
-
+use super::{Household, HouseholdCore, HouseholdID, MemberIdx, Offer};
 
 #[derive(Compact, Clone)]
 pub struct GrainFarm {
@@ -46,7 +45,7 @@ impl GrainFarm {
                     Offer::new(
                         MemberIdx(0),
                         TimeOfDayRange::new(5, 0, 15, 0),
-                        Deal::new(Some((Resource::Money, 40.0)), Duration::from_hours(4)),
+                        Deal::new(vec![(Resource::Money, 40.0)], Duration::from_hours(4)),
                         2,
                         false
                     ),
@@ -105,7 +104,7 @@ impl Household for GrainFarm {
     }
 }
 
-use core::simulation::{Simulatable, SimulatableID, Sleeper, SleeperID, Instant,
+use core::simulation::{Instant, Simulatable, SimulatableID, Sleeper, SleeperID,
                        TICKS_PER_SIM_SECOND};
 const UPDATE_EVERY_N_SECS: usize = 4;
 
@@ -130,7 +129,7 @@ impl EvaluationRequester for GrainFarm {
     fn on_result(&mut self, _e: &EvaluatedSearchResult, _: &mut World) {}
 }
 
-use transport::pathfinding::{RoughLocationID, RoughLocation, RoughLocationResolve};
+use transport::pathfinding::{RoughLocation, RoughLocationID, RoughLocationResolve};
 
 impl RoughLocation for GrainFarm {
     fn resolve(&self) -> RoughLocationResolve {
@@ -138,7 +137,7 @@ impl RoughLocation for GrainFarm {
     }
 }
 
-use transport::pathfinding::trip::{TripListener, TripListenerID, TripID, TripResult};
+use transport::pathfinding::trip::{TripID, TripListener, TripListenerID, TripResult};
 
 impl TripListener for GrainFarm {
     fn trip_created(&mut self, trip: TripID, world: &mut World) {

--- a/game/economy/households/grocery_shop/mod.rs
+++ b/game/economy/households/grocery_shop/mod.rs
@@ -1,11 +1,11 @@
-use kay::{ActorSystem, World, TypedID, Actor};
-use core::simulation::{TimeOfDay, TimeOfDayRange, Duration, SimulationID, Ticks};
+use kay::{Actor, ActorSystem, TypedID, World};
+use core::simulation::{Duration, SimulationID, Ticks, TimeOfDay, TimeOfDayRange};
 use economy::resources::Resource;
 use economy::resources::Resource::*;
-use economy::market::{Deal, EvaluationRequester, EvaluationRequesterID, EvaluatedSearchResult};
+use economy::market::{Deal, EvaluatedSearchResult, EvaluationRequester, EvaluationRequesterID};
 use economy::buildings::BuildingID;
 
-use super::{Household, HouseholdID, HouseholdCore, MemberIdx, Offer};
+use super::{Household, HouseholdCore, HouseholdID, MemberIdx, Offer};
 
 #[derive(Compact, Clone)]
 pub struct GroceryShop {
@@ -45,7 +45,7 @@ impl GroceryShop {
                     Offer::new(
                         MemberIdx(0),
                         TimeOfDayRange::new(7, 0, 15, 0),
-                        Deal::new(Some((Money, 50.0)), Duration::from_hours(5)),
+                        Deal::new(vec![(Money, 50.0)], Duration::from_hours(5)),
                         5,
                         false
                     ),
@@ -80,22 +80,9 @@ impl Household for GroceryShop {
         let hour = time.hours_minutes().0;
 
         let bihourly_importance = match resource {
-            BakedGoods | Produce | Grain | Flour | Meat | DairyGoods => Some(
-                [
-                    0,
-                    0,
-                    0,
-                    1,
-                    1,
-                    1,
-                    1,
-                    1,
-                    1,
-                    0,
-                    0,
-                    0,
-                ],
-            ),
+            BakedGoods | Produce | Grain | Flour | Meat | DairyGoods => {
+                Some([0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0])
+            }
             _ => None,
         };
 
@@ -184,7 +171,7 @@ impl EvaluationRequester for GroceryShop {
     }
 }
 
-use core::simulation::{Simulatable, SimulatableID, Sleeper, SleeperID, Instant,
+use core::simulation::{Instant, Simulatable, SimulatableID, Sleeper, SleeperID,
                        TICKS_PER_SIM_SECOND};
 const UPDATE_EVERY_N_SECS: usize = 4;
 
@@ -204,7 +191,7 @@ impl Sleeper for GroceryShop {
     }
 }
 
-use transport::pathfinding::{RoughLocationID, RoughLocation, RoughLocationResolve};
+use transport::pathfinding::{RoughLocation, RoughLocationID, RoughLocationResolve};
 
 impl RoughLocation for GroceryShop {
     fn resolve(&self) -> RoughLocationResolve {
@@ -212,7 +199,7 @@ impl RoughLocation for GroceryShop {
     }
 }
 
-use transport::pathfinding::trip::{TripListener, TripListenerID, TripID, TripResult};
+use transport::pathfinding::trip::{TripID, TripListener, TripListenerID, TripResult};
 
 impl TripListener for GroceryShop {
     fn trip_created(&mut self, trip: TripID, world: &mut World) {

--- a/game/economy/households/mill/mod.rs
+++ b/game/economy/households/mill/mod.rs
@@ -1,12 +1,11 @@
-use kay::{ActorSystem, World, TypedID, Actor};
-use core::simulation::{TimeOfDay, TimeOfDayRange, Duration, SimulationID, Ticks};
+use kay::{Actor, ActorSystem, TypedID, World};
+use core::simulation::{Duration, SimulationID, Ticks, TimeOfDay, TimeOfDayRange};
 use economy::resources::Resource;
 use economy::resources::Resource::*;
-use economy::market::{Deal, EvaluationRequester, EvaluationRequesterID, EvaluatedSearchResult};
+use economy::market::{Deal, EvaluatedSearchResult, EvaluationRequester, EvaluationRequesterID};
 use economy::buildings::BuildingID;
 
-use super::{Household, HouseholdID, HouseholdCore, MemberIdx, Offer};
-
+use super::{Household, HouseholdCore, HouseholdID, MemberIdx, Offer};
 
 #[derive(Compact, Clone)]
 pub struct Mill {
@@ -46,7 +45,7 @@ impl Mill {
                     Offer::new(
                         MemberIdx(0),
                         TimeOfDayRange::new(5, 0, 15, 0),
-                        Deal::new(Some((Resource::Money, 40.0)), Duration::from_hours(4)),
+                        Deal::new(vec![(Resource::Money, 40.0)], Duration::from_hours(4)),
                         3,
                         false
                     ),
@@ -119,7 +118,7 @@ impl Household for Mill {
     }
 }
 
-use core::simulation::{Simulatable, SimulatableID, Sleeper, SleeperID, Instant,
+use core::simulation::{Instant, Simulatable, SimulatableID, Sleeper, SleeperID,
                        TICKS_PER_SIM_SECOND};
 const UPDATE_EVERY_N_SECS: usize = 4;
 
@@ -144,7 +143,7 @@ impl EvaluationRequester for Mill {
     fn on_result(&mut self, _e: &EvaluatedSearchResult, _: &mut World) {}
 }
 
-use transport::pathfinding::{RoughLocationID, RoughLocation, RoughLocationResolve};
+use transport::pathfinding::{RoughLocation, RoughLocationID, RoughLocationResolve};
 
 impl RoughLocation for Mill {
     fn resolve(&self) -> RoughLocationResolve {
@@ -152,7 +151,7 @@ impl RoughLocation for Mill {
     }
 }
 
-use transport::pathfinding::trip::{TripListener, TripListenerID, TripID, TripResult};
+use transport::pathfinding::trip::{TripID, TripListener, TripListenerID, TripResult};
 
 impl TripListener for Mill {
     fn trip_created(&mut self, trip: TripID, world: &mut World) {

--- a/game/economy/households/neighboring_town_trade/mod.rs
+++ b/game/economy/households/neighboring_town_trade/mod.rs
@@ -1,14 +1,14 @@
-use kay::{ActorSystem, World, Actor};
-use core::simulation::{TimeOfDay, TimeOfDayRange, Duration, Instant, Simulatable, SimulatableID,
-                       SimulationID, Ticks};
+use kay::{Actor, ActorSystem, World};
+use core::simulation::{Duration, Instant, Simulatable, SimulatableID, SimulationID, Ticks,
+                       TimeOfDay, TimeOfDayRange};
 use economy::resources::Resource;
 use economy::resources::Resource::*;
-use economy::market::{Deal, EvaluationRequester, EvaluationRequesterID, EvaluatedSearchResult};
+use economy::market::{Deal, EvaluatedSearchResult, EvaluationRequester, EvaluationRequesterID};
 use economy::buildings::BuildingID;
 use transport::pathfinding::RoughLocationID;
-use transport::pathfinding::trip::{TripListener, TripListenerID, TripID, TripResult};
+use transport::pathfinding::trip::{TripID, TripListener, TripListenerID, TripResult};
 
-use super::{Household, HouseholdID, HouseholdCore, MemberIdx, Offer};
+use super::{Household, HouseholdCore, HouseholdID, MemberIdx, Offer};
 
 #[derive(Compact, Clone)]
 pub struct NeighboringTownTrade {
@@ -30,9 +30,9 @@ impl NeighboringTownTrade {
             Offer::new(
                 MemberIdx(0),
                 TimeOfDayRange::new(5, 0, 15, 0),
-                Deal::new(Some((Resource::Money, 50.0)), Duration::from_hours(5)),
+                Deal::new(vec![(Resource::Money, 50.0)], Duration::from_hours(5)),
                 300,
-                false
+                false,
             ),
             // Offer::new(
             //     MemberIdx(0),
@@ -62,7 +62,7 @@ impl NeighboringTownTrade {
                     Duration::from_minutes(30),
                 ),
                 32,
-                false
+                false,
             ),
             Offer::new(
                 MemberIdx(0),
@@ -72,7 +72,7 @@ impl NeighboringTownTrade {
                     Duration::from_minutes(10),
                 ),
                 8,
-                false
+                false,
             ),
             Offer::new(
                 MemberIdx(0),
@@ -82,7 +82,7 @@ impl NeighboringTownTrade {
                     Duration::from_minutes(10),
                 ),
                 8,
-                false
+                false,
             ),
             Offer::new(
                 MemberIdx(0),
@@ -92,7 +92,7 @@ impl NeighboringTownTrade {
                     Duration::from_minutes(10),
                 ),
                 8,
-                false
+                false,
             ),
             Offer::new(
                 MemberIdx(0),
@@ -105,7 +105,7 @@ impl NeighboringTownTrade {
                     Duration::from_minutes(10),
                 ),
                 60,
-                false
+                false,
             ),
             Offer::new(
                 MemberIdx(0),
@@ -115,7 +115,7 @@ impl NeighboringTownTrade {
                     Duration::from_minutes(10),
                 ),
                 8,
-                false
+                false,
             ),
             Offer::new(
                 MemberIdx(0),
@@ -128,7 +128,7 @@ impl NeighboringTownTrade {
                     Duration::from_minutes(10),
                 ),
                 8,
-                false
+                false,
             ),
             // Offer::new(
             //     MemberIdx(0),
@@ -273,7 +273,6 @@ impl EvaluationRequester for NeighboringTownTrade {
         );
     }
 }
-
 
 impl TripListener for NeighboringTownTrade {
     fn trip_created(&mut self, trip: TripID, world: &mut World) {

--- a/game/economy/households/vegetable_farm/mod.rs
+++ b/game/economy/households/vegetable_farm/mod.rs
@@ -1,12 +1,11 @@
-use kay::{ActorSystem, World, TypedID, Actor};
-use core::simulation::{TimeOfDay, TimeOfDayRange, Duration, SimulationID, Ticks};
+use kay::{Actor, ActorSystem, TypedID, World};
+use core::simulation::{Duration, SimulationID, Ticks, TimeOfDay, TimeOfDayRange};
 use economy::resources::Resource;
 use economy::resources::Resource::*;
-use economy::market::{Deal, EvaluationRequester, EvaluationRequesterID, EvaluatedSearchResult};
+use economy::market::{Deal, EvaluatedSearchResult, EvaluationRequester, EvaluationRequesterID};
 use economy::buildings::BuildingID;
 
-use super::{Household, HouseholdID, HouseholdCore, MemberIdx, Offer};
-
+use super::{Household, HouseholdCore, HouseholdID, MemberIdx, Offer};
 
 #[derive(Compact, Clone)]
 pub struct VegetableFarm {
@@ -46,7 +45,7 @@ impl VegetableFarm {
                     Offer::new(
                         MemberIdx(0),
                         TimeOfDayRange::new(5, 0, 15, 0),
-                        Deal::new(Some((Resource::Money, 40.0)), Duration::from_hours(4)),
+                        Deal::new(vec![(Resource::Money, 40.0)], Duration::from_hours(4)),
                         2,
                         false
                     ),
@@ -105,7 +104,7 @@ impl Household for VegetableFarm {
     }
 }
 
-use core::simulation::{Simulatable, SimulatableID, Sleeper, SleeperID, Instant,
+use core::simulation::{Instant, Simulatable, SimulatableID, Sleeper, SleeperID,
                        TICKS_PER_SIM_SECOND};
 const UPDATE_EVERY_N_SECS: usize = 4;
 
@@ -130,7 +129,7 @@ impl EvaluationRequester for VegetableFarm {
     fn on_result(&mut self, _e: &EvaluatedSearchResult, _: &mut World) {}
 }
 
-use transport::pathfinding::{RoughLocationID, RoughLocation, RoughLocationResolve};
+use transport::pathfinding::{RoughLocation, RoughLocationID, RoughLocationResolve};
 
 impl RoughLocation for VegetableFarm {
     fn resolve(&self) -> RoughLocationResolve {
@@ -138,7 +137,7 @@ impl RoughLocation for VegetableFarm {
     }
 }
 
-use transport::pathfinding::trip::{TripListener, TripListenerID, TripID, TripResult};
+use transport::pathfinding::trip::{TripID, TripListener, TripListenerID, TripResult};
 
 impl TripListener for VegetableFarm {
     fn trip_created(&mut self, trip: TripID, world: &mut World) {


### PR DESCRIPTION
as per https://github.com/citybound/citybound/issues/249
citybound crashes with ud2 when trying to 
```
Process 42500 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_INSTRUCTION (code=EXC_I386_INVOP, subcode=0x0)
    frame #0: 0x00000001001482a5 citybound`kay::actor_system::ActorSystem::add_spawner::_$u7b$$u7b$closure$u7d$$u7d$::h0ad618cd037e08ef + 37
citybound`kay::actor_system::ActorSystem::add_spawner::_$u7b$$u7b$closure$u7d$$u7d$::h0ad618cd037e08ef:
->  0x1001482a5 <+37>: ud2
    0x1001482a7 <+39>: ud2
    0x1001482a9 <+41>: nopl   (%rax)
```
somewhere here:
```
vec![
                Offer::new(
                    MemberIdx(0),
                    TimeOfDayRange::new(16, 0, 11, 0),
                    Deal::new(Some((Awakeness, 3.0)), Duration::from_hours(1)),
                    1,
                    true
                ),
            ].into(),
```
when replacing with this code
```
vec![
                Offer::new(
                    MemberIdx(0),
                    TimeOfDayRange::new(16, 0, 11, 0),
                    Deal::new(vec![(Awakeness, 3.0)], Duration::from_hours(1)),
                    1,
                    true
                ),
            ].into(),
```
crashes stop, and rust does not generate ud2 anymore!

the diff is large, but the essence is replacing Some(tuple) with vec![tuple]



tried to reproduce it on rust playground, replacing CVec with Vec - it does not crash :(
https://play.rust-lang.org/?gist=d4a376b499500efb375f412c2733ae63&version=nightly