### PR TITLE
Update rust and clippy version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ sudo: required
 
 # TODO This is the Rust channel that build jobs will use by default but can be
 # overridden on a case by case basis down below
-rust: nightly-2018-06-02
+rust: nightly-2018-07-16
 osx_image: xcode8.2
 
 env:
@@ -34,7 +34,8 @@ install:
   - source ~/.cargo/env || true
   - rustup component add rustfmt-preview --toolchain $TRAVIS_RUST_VERSION
   - cargo fmt --verbose --version
-  - cargo install -f clippy --vers 0.0.206
+  - rustup component add clippy-preview --toolchain $TRAVIS_RUST_VERSION
+  - cargo clippy --verbose --version
 
 script:
   - cargo build --verbose

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ You can make suggestions of every kind:
 
 ## Compiling Citybound yourself
 
-Currently Citybound is built with Rust `nightly-2018-06-02'
+Currently Citybound is built with Rust `nightly-2018-07-16'
 
 **If you want a working version of Citybound,** compile a commit that corresponds to a [release](https://github.com/citybound/citybound/releases), since master might temporarily break or represents work-in-progress state.
 
@@ -62,12 +62,12 @@ Recommended setup:
 * `git clone https://github.com/citybound/citybound.git`
 * `cd citybound`
 * Windows:
-  * `rustup override add nightly-2018-06-02-x86_64-pc-windows-msvc`
+  * `rustup override add nightly-2018-07-16-x86_64-pc-windows-msvc`
   * Install the [Visual C++ 2015 Build Tools](http://landinghub.visualstudio.com/visual-cpp-build-tools), unless you have Visual Studio 2015
 * MacOS:
-  * `rustup override add nightly-2018-06-02-x86_64-apple-darwin`
+  * `rustup override add nightly-2018-07-16-x86_64-apple-darwin`
 * Linux:
-  * `rustup override add nightly-2018-06-02-x86_64-unknown-linux-gnu`
+  * `rustup override add nightly-2018-07-16-x86_64-unknown-linux-gnu`
   * `sudo apt install build-essential` (for Ubuntu)
 * `cargo run --release` (Debug mode is generally too slow to interact with)
 
@@ -93,7 +93,7 @@ Recommended setup:
     * Add the following user settings in VSCode
       * `"rust.cargoHomePath": "C:\\firstname\\.cargo"`,
       * `"rust.racerPath": "C:\\firstname\\.cargo\\bin\\racer.exe"`,
-      * `"rust.rustLangSrcPath": "C:\\firstname\\.rustup\\toolchains\\nightly-2018-06-02-x86_64-pc-windows-msvc\\lib\\rustlib\\src\\rust\\src"`
+      * `"rust.rustLangSrcPath": "C:\\firstname\\.rustup\\toolchains\\nightly-2018-07-16-x86_64-pc-windows-msvc\\lib\\rustlib\\src\\rust\\src"`
   * Otherwise it "should just work"
 * For debugging 
   * Linux/MacOS: 
@@ -106,11 +106,11 @@ Recommended setup:
 
 ## Conforming to style
 
-* install rustfmt: `rustup component add rustfmt-preview --toolchain nightly-2018-06-02` **and please make sure to use the same version as noted here** (pinned now, but might change from time to time)
+* install rustfmt: `rustup component add rustfmt-preview --toolchain nightly-2018-07-16` **and please make sure to use the same version as noted here** (pinned now, but might change from time to time)
 * run rustfmt on the whole repo:
   `rustfmt ./game/main.rs ./engine/*/src/lib.rs`
   (using default settings) - if there are any overlong lines it can't fix, please fix them manually.
-* install clippy: `cargo install -f clippy --vers 0.0.206` **and please make sure to use the same version as noted here** (pinned now, but might change from time to time)
+* install clippy: `rustup component add clippy-preview --toolchain nightly-2018-07-16` **and please make sure to use the same version as noted here** (pinned now, but might change from time to time)
 * Run clippy on the whole repo: `cargo clippy` and adress all warnings in code that you added
 
 ## Have a question? Want to discuss something?

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,6 +737,8 @@ dependencies = [
  "kay 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "kay_codegen 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lyon_tessellation 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/game_common/engine/monet/Cargo.toml
+++ b/game_common/engine/monet/Cargo.toml
@@ -13,6 +13,8 @@ kay = "0.2.3"
 compact = "0.2.4"
 compact_macros = "0.1.0"
 descartes = "0.1.3"
+serde = "1.0"
+serde_derive = "1.0"
 
 [build-dependencies]
 kay_codegen = "0.1.0"

--- a/game_common/engine/monet/src/lib.rs
+++ b/game_common/engine/monet/src/lib.rs
@@ -11,6 +11,8 @@ extern crate compact_macros;
 extern crate fnv;
 extern crate itertools;
 extern crate lyon_tessellation;
+#[macro_use]
+extern crate serde_derive;
 
 mod mesh;
 mod mesh_actors;


### PR DESCRIPTION
Now clippy ships as prebuilt component with rust. This PR updates rust and use clippy ships with defined rust version.
It also have a strange error with `rustfmt` as `kay_codegen` cann't generate file.