### PR TITLE
Adding configuration for building in Docker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,16 @@ Recommended setup:
 
 * Open the displayed address in your browser
 
+## Compiling and running Citybound in Docker
+
+To run Citybound from a Docker container, run the following command:
+
+```bash
+docker-compose up
+```
+
+Then, open [http://localhost:1234](http://localhost:1234) in your browser to begin playing.
+
 ## Guidelines
 
 * **Make sure to <a href="https://www.clahub.com/agreements/citybound/citybound">sign the Contributor License Agreement</a>.**

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM rust:1.32
+
+RUN apt-get update
+RUN apt-get install --yes \
+      build-essential \
+      git \
+      curl \
+      libssl-dev \
+      pkg-config
+
+# Workaround because npm run ensure-tooling fails to install cargo-web.
+RUN cargo install cargo-web --version 0.6.16
+
+COPY . /app
+WORKDIR /app
+
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
+    apt-get install --yes \
+      nodejs
+RUN npm run ensure-tooling
+
+RUN cd cb_browser_ui && \
+    npm install && \
+    npm run build
+
+RUN npm run build-server
+
+EXPOSE 1234
+EXPOSE 9999
+
+ENTRYPOINT set -xe && \
+  target/release/citybound \
+    --bind 0.0.0.0:1234 \
+    --bind-sim 0.0.0.0:9999

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.2'
+services:
+  citybound:
+    build: .
+    container_name: citybound
+    ports:
+      - "127.0.0.1:1234:1234"
+      - "127.0.0.1:9999:9999"


### PR DESCRIPTION
This adds a configuration for building citybound in Docker so that users can compile it on any OS and not worry about dependencies. Updates the CONTRIBUTING.md with instructions on how to compile using Docker.

If you configure automatic builds on Docker Cloud (free for open source projects and easy to set up), users can run Citybound in a single command without ever cloning the repo. Here's an example with my copy of the Docker image:

```bash
docker run \
  -it \
  --publish 127.0.0.1:1234:1234 \
  --publish 127.0.0.1:9999:9999 \
  --name citybound mtlynch/citybound
```