### PR TITLE
Suppress context menu on Stage

### DIFF
--- a/cb_browser_ui/src/stage/Stage.js
+++ b/cb_browser_ui/src/stage/Stage.js
@@ -105,7 +105,8 @@ export default class Stage extends React.Component {
             onPointerUp: onMouseUp,
             onTouchStart: e => onMouseDown(e.changedTouches[0]),
             onTouchMove: e => onMouseMove(e.changedTouches[0]),
-            onTouchEnd: e => onMouseUp(e.changedTouches[0])
+            onTouchEnd: e => onMouseUp(e.changedTouches[0]),
+            onContextMenu: e => { e.preventDefault(); return false }
         });
     }
 


### PR DESCRIPTION
Fixes #313 

Adds an event handler for `onContextMenu` with `event.preventDefault; return false` on the Stage.