### PR TITLE
Use portable RecommendedWatcher type instead of MacOS FsEventWatcher

### DIFF
--- a/cb_util/src/config_manager/mod.rs
+++ b/cb_util/src/config_manager/mod.rs
@@ -71,7 +71,7 @@ use notify::Watcher;
 #[cfg(feature = "server")]
 struct ConfigFileWatcherState {
     receiver: Receiver<notify::DebouncedEvent>,
-    watcher: notify::FsEventWatcher,
+    watcher: notify::RecommendedWatcher,
 }
 
 #[derive(Compact, Clone)]


### PR DESCRIPTION
Referencing the MacOS-specific `Watcher` implementation just produces a compiler error on linux, and presumably windows too. Switching to `RecommendedWatcher` should be quite safe: https://docs.rs/notify/4.0.15/src/notify/lib.rs.html#621